### PR TITLE
Downgrade guava to 19.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -51,6 +51,12 @@
         <dropwizard.version>1.1.0</dropwizard.version>
         <finatra.version>2.10.0</finatra.version>
         <governator.version>1.15.10</governator.version>
+        <!--
+        Downgrade guava.version to allow for better backwards compatibility
+        with embedded applications. Specifically, the checkState signature
+        auto-generated in FreeBuilder *_Builder classes.
+        -->
+        <guava.version>19.0</guava.version>
         <!-- NOTE: Must match what's available in governator.version -->
         <hibernate.version>5.3.4.Final</hibernate.version>
         <!-- NOTE: Must match what's available in governator.version -->


### PR DESCRIPTION
The FreeBuilder library includes guava utilities in its auto-generated `*_Builder` classes if guava is available at compile time. Unfortunately, there's a backwards compatibility issue between guava 19.0 and guava 20.0:

Generated code with guava:
```java
public GenericWorkerApp build() {
    Preconditions.checkState(_unsetProperties.isEmpty(), "Not set: %s", _unsetProperties);
    return new GenericWorkerApp_Builder.Value(this);
  }
```
The call to `checkState` is interpreted differently between guava 19.0 and 20.0:

19.0 - [javadoc](https://google.github.io/guava/releases/19.0/api/docs/com/google/common/base/Preconditions.html#checkState(boolean,%20java.lang.String,%20java.lang.Object...)):
```java
checkState(boolean expression, String errorMessageTemplate, Object... errorMessageArgs)
```
20.0 - [javadoc](https://google.github.io/guava/releases/20.0/api/docs/com/google/common/base/Preconditions.html#checkState-boolean-java.lang.String-java.lang.Object-):
```java
checkState(boolean b, String errorMessageTemplate, Object p1)
```

We've seen this imcompatibility cause runtime problems in environments using guava 19.0. So downgrading the whole appbuilder framework to that version.