### PR TITLE
Add Request Tracing

### DIFF
--- a/app-core-test/src/test/java/net/spals/appbuilder/app/core/generic/MinimalGenericWorkerAppFTest.java
+++ b/app-core-test/src/test/java/net/spals/appbuilder/app/core/generic/MinimalGenericWorkerAppFTest.java
@@ -1,15 +1,20 @@
 package net.spals.appbuilder.app.core.generic;
 
+import com.google.inject.ConfigurationException;
+import com.google.inject.Injector;
+import com.google.inject.Key;
+import com.google.inject.TypeLiteral;
 import com.typesafe.config.ConfigFactory;
+import io.opentracing.Tracer;
+import net.spals.appbuilder.executor.core.ExecutorServiceFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
-import javax.ws.rs.core.Configurable;
-
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.sameInstance;
+import static org.hamcrest.Matchers.*;
+import static com.googlecode.catchexception.CatchException.*;
 
 /**
  * Functional tests for a minimal {@link GenericWorkerApp}
@@ -34,5 +39,19 @@ public class MinimalGenericWorkerAppFTest {
     @Test
     public void testMinimalServiceConfig() {
         assertThat(minimalApp.getServiceConfig(), is(ConfigFactory.empty()));
+    }
+
+    @DataProvider
+    Object[][] noDefaultServiceInjectionProvider() {
+        return new Object[][] {
+                {TypeLiteral.get(ExecutorServiceFactory.class)},
+                {TypeLiteral.get(Tracer.class)},
+        };
+    }
+
+    @Test(dataProvider = "noDefaultServiceInjectionProvider")
+    public void testNoDefaultServiceInjection(final TypeLiteral<?> typeLiteral) {
+        final Injector serviceInjector = minimalApp.getServiceInjector();
+        verifyException(() -> serviceInjector.getInstance(Key.get(typeLiteral)), ConfigurationException.class);
     }
 }

--- a/app-core-test/src/test/java/net/spals/appbuilder/app/core/generic/SampleGenericWorkerAppFTest.java
+++ b/app-core-test/src/test/java/net/spals/appbuilder/app/core/generic/SampleGenericWorkerAppFTest.java
@@ -8,8 +8,8 @@ import com.typesafe.config.Config;
 import io.opentracing.NoopTracer;
 import io.opentracing.Tracer;
 import net.spals.appbuilder.app.core.sample.SampleCoreBootstrapModule;
-import net.spals.appbuilder.app.core.sample.SampleCoreGuiceModule;
 import net.spals.appbuilder.app.core.sample.SampleCoreCustomService;
+import net.spals.appbuilder.app.core.sample.SampleCoreGuiceModule;
 import net.spals.appbuilder.config.service.ServiceScan;
 import net.spals.appbuilder.executor.core.ExecutorServiceFactory;
 import net.spals.appbuilder.filestore.core.FileStore;
@@ -45,7 +45,6 @@ public class SampleGenericWorkerAppFTest {
             .setServiceConfigFromClasspath("config/sample-generic-service.conf")
             .setServiceScan(new ServiceScan.Builder()
                     .addServicePackages("net.spals.appbuilder.app.core.sample")
-                    .addDefaultServices(ExecutorServiceFactory.class)
                     .addDefaultServices(FileStore.class)
                     .addDefaultServices(MapStore.class)
                     .addDefaultServices(MessageConsumer.class, MessageProducer.class)

--- a/app-core-test/src/test/java/net/spals/appbuilder/app/core/generic/SampleGenericWorkerAppFTest.java
+++ b/app-core-test/src/test/java/net/spals/appbuilder/app/core/generic/SampleGenericWorkerAppFTest.java
@@ -5,6 +5,8 @@ import com.google.inject.Key;
 import com.google.inject.TypeLiteral;
 import com.google.inject.name.Names;
 import com.typesafe.config.Config;
+import io.opentracing.NoopTracer;
+import io.opentracing.Tracer;
 import net.spals.appbuilder.app.core.sample.SampleCoreBootstrapModule;
 import net.spals.appbuilder.app.core.sample.SampleCoreGuiceModule;
 import net.spals.appbuilder.app.core.sample.SampleCoreCustomService;
@@ -168,5 +170,11 @@ public class SampleGenericWorkerAppFTest {
                 serviceInjector.getInstance(Key.get(modelSerializerMapKey));
         assertThat(modelSerializerMap, aMapWithSize(1));
         assertThat(modelSerializerMap, hasKey("pojo"));
+    }
+
+    @Test
+    public void testMonitorInjection() {
+        final Injector serviceInjector = sampleApp.getServiceInjector();
+        assertThat(serviceInjector.getInstance(Tracer.class), instanceOf(NoopTracer.class));
     }
 }

--- a/app-core-test/src/test/java/net/spals/appbuilder/app/core/jaxrs/MinimalJaxRsWebAppFTest.java
+++ b/app-core-test/src/test/java/net/spals/appbuilder/app/core/jaxrs/MinimalJaxRsWebAppFTest.java
@@ -1,9 +1,16 @@
 package net.spals.appbuilder.app.core.jaxrs;
 
+import com.google.inject.ConfigurationException;
+import com.google.inject.Injector;
+import com.google.inject.Key;
+import com.google.inject.TypeLiteral;
 import com.typesafe.config.ConfigFactory;
+import io.opentracing.Tracer;
 import net.spals.appbuilder.app.core.generic.GenericWorkerApp;
+import net.spals.appbuilder.executor.core.ExecutorServiceFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 import javax.servlet.Filter;
@@ -12,6 +19,7 @@ import javax.ws.rs.core.Configurable;
 
 import java.util.function.BiFunction;
 
+import static com.googlecode.catchexception.CatchException.verifyException;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.sameInstance;
@@ -46,5 +54,19 @@ public class MinimalJaxRsWebAppFTest {
     @Test
     public void testMinimalServiceConfig() {
         assertThat(minimalApp.getServiceConfig(), is(ConfigFactory.empty()));
+    }
+
+    @DataProvider
+    Object[][] noDefaultServiceInjectionProvider() {
+        return new Object[][] {
+                {TypeLiteral.get(ExecutorServiceFactory.class)},
+                {TypeLiteral.get(Tracer.class)},
+        };
+    }
+
+    @Test(dataProvider = "noDefaultServiceInjectionProvider")
+    public void testNoDefaultServiceInjection(final TypeLiteral<?> typeLiteral) {
+        final Injector serviceInjector = minimalApp.getServiceInjector();
+        verifyException(() -> serviceInjector.getInstance(Key.get(typeLiteral)), ConfigurationException.class);
     }
 }

--- a/app-core-test/src/test/java/net/spals/appbuilder/app/core/modules/AutoBindConfigModuleTest.java
+++ b/app-core-test/src/test/java/net/spals/appbuilder/app/core/modules/AutoBindConfigModuleTest.java
@@ -7,6 +7,7 @@ import com.typesafe.config.ConfigFactory;
 import net.spals.appbuilder.config.TaggedConfig;
 import net.spals.appbuilder.config.message.MessageConsumerConfig;
 import net.spals.appbuilder.config.message.MessageProducerConfig;
+import net.spals.appbuilder.monitor.core.TracerTag;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
@@ -46,6 +47,10 @@ public class AutoBindConfigModuleTest {
                 .setGlobalId("myId")
                 .setDestination("kafka").build();
 
+        final Map<String, Object> configMapTracing = ImmutableMap.of("myTag.tracing.tagValue", "value");
+        final TracerTag expectedTracerTag = new TracerTag.Builder().setTag("myTag")
+                .setValue("value").build();
+
         final Map<String, Object> configMapMultiConsumer = ImmutableMap.<String, Object>builder()
                 .put("myTag1.consumer.channel", "myChannel")
                 .put("myTag1.consumer.format", "json")
@@ -71,11 +76,14 @@ public class AutoBindConfigModuleTest {
                 // Case: No configs found for auto-binding
                 {ConfigFactory.empty(), "consumer", MessageConsumerConfig.class, Collections.emptyMap()},
                 {ConfigFactory.empty(), "producer", MessageProducerConfig.class, Collections.emptyMap()},
+                {ConfigFactory.empty(), "tracing", TracerTag.class, Collections.emptyMap()},
                 // Basic cases
                 {ConfigFactory.parseMap(configMapConsumer), "consumer", MessageConsumerConfig.class,
                         ImmutableMap.of("myTag", expectedConsumerConfig)},
                 {ConfigFactory.parseMap(configMapProducer), "producer", MessageProducerConfig.class,
                         ImmutableMap.of("myTag", expectedProducerConfig)},
+                {ConfigFactory.parseMap(configMapTracing), "tracing", TracerTag.class,
+                        ImmutableMap.of("myTag", expectedTracerTag)},
                 // Case: Multiple auto-bound configurations
                 {ConfigFactory.parseMap(configMapMultiConsumer), "consumer", MessageConsumerConfig.class,
                         ImmutableMap.of("myTag1", expectedConsumerConfig1, "myTag2", expectedConsumerConfig2)},

--- a/app-core/pom.xml
+++ b/app-core/pom.xml
@@ -47,6 +47,10 @@
             <artifactId>config</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.opentracing.contrib</groupId>
+            <artifactId>opentracing-jaxrs2</artifactId>
+        </dependency>
+        <dependency>
             <groupId>javax.servlet</groupId>
             <artifactId>javax.servlet-api</artifactId>
         </dependency>

--- a/app-core/pom.xml
+++ b/app-core/pom.xml
@@ -74,7 +74,17 @@
         </dependency>
         <dependency>
             <groupId>net.spals.appbuilder</groupId>
+            <artifactId>spals-appbuilder-executor-core</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>net.spals.appbuilder</groupId>
             <artifactId>spals-appbuilder-graph</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>net.spals.appbuilder</groupId>
+            <artifactId>spals-appbuilder-monitor-core</artifactId>
+            <scope>runtime</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.bcel</groupId>

--- a/app-core/pom.xml
+++ b/app-core/pom.xml
@@ -84,7 +84,6 @@
         <dependency>
             <groupId>net.spals.appbuilder</groupId>
             <artifactId>spals-appbuilder-monitor-core</artifactId>
-            <scope>runtime</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.bcel</groupId>

--- a/app-core/src/main/java/net/spals/appbuilder/app/core/jaxrs/JaxRsMonitorModule.java
+++ b/app-core/src/main/java/net/spals/appbuilder/app/core/jaxrs/JaxRsMonitorModule.java
@@ -1,0 +1,55 @@
+package net.spals.appbuilder.app.core.jaxrs;
+
+import com.google.inject.AbstractModule;
+import com.google.inject.TypeLiteral;
+import com.google.inject.matcher.Matcher;
+import com.google.inject.matcher.Matchers;
+import com.google.inject.spi.ProvisionListener;
+import com.netflix.governator.lifecycle.DefaultLifecycleListener;
+import io.opentracing.Tracer;
+import io.opentracing.contrib.jaxrs2.server.ServerTracingDynamicFeature;
+import net.spals.appbuilder.app.core.matcher.BindingMatchers;
+import net.spals.appbuilder.app.core.matcher.TypeLiteralMatchers;
+import org.inferred.freebuilder.FreeBuilder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.ws.rs.Path;
+import javax.ws.rs.container.DynamicFeature;
+import javax.ws.rs.core.Configurable;
+
+/**
+ * @author tkral
+ */
+@FreeBuilder
+public abstract class JaxRsMonitorModule extends AbstractModule
+    implements ProvisionListener {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(JaxRsMonitorModule.class);
+
+    public abstract Configurable<?> getConfigurable();
+
+    public static class Builder extends JaxRsMonitorModule_Builder {  }
+
+    @Override
+    protected void configure() {
+        final Matcher bindingMatcher = BindingMatchers.withKeyTypeSubclassOf(Tracer.class);
+        bindListener(bindingMatcher, this);
+    }
+
+    @Override
+    public <T> void onProvision(final ProvisionInvocation<T> provision) {
+        final Object monitorComponent = provision.provision();
+
+        if (Tracer.class.isAssignableFrom(monitorComponent.getClass())) {
+            registerTracer((Tracer)monitorComponent);
+        }
+    }
+
+    void registerTracer(final Tracer tracer) {
+        LOGGER.info("Enabling JaxRs server request tracing with OpenTracing");
+        final ServerTracingDynamicFeature serverTracing =
+                new ServerTracingDynamicFeature.Builder(tracer).build();
+        getConfigurable().register(serverTracing);
+    }
+}

--- a/app-core/src/main/java/net/spals/appbuilder/app/core/jaxrs/JaxRsWebApp.java
+++ b/app-core/src/main/java/net/spals/appbuilder/app/core/jaxrs/JaxRsWebApp.java
@@ -32,6 +32,8 @@ public abstract class JaxRsWebApp implements App {
     public static class Builder extends JaxRsWebApp_Builder implements WebAppBuilder<JaxRsWebApp> {
 
         private final GenericWorkerApp.Builder appDelegateBuilder;
+        private final JaxRsMonitorModule.Builder monitorModuleBuilder =
+                new JaxRsMonitorModule.Builder();
         private final JaxRsWebServerModule.Builder webServerModuleBuilder =
                 new JaxRsWebServerModule.Builder();
 
@@ -84,6 +86,7 @@ public abstract class JaxRsWebApp implements App {
 
         @Override
         public Builder setConfigurable(final Configurable<?> configurable) {
+            monitorModuleBuilder.setConfigurable(configurable);
             webServerModuleBuilder.setConfigurable(configurable);
             return super.setConfigurable(configurable);
         }
@@ -108,10 +111,12 @@ public abstract class JaxRsWebApp implements App {
 
         @Override
         public JaxRsWebApp build() {
+            appDelegateBuilder.addModule(monitorModuleBuilder.build());
+
             webServerModuleBuilder.setServiceGraph(appDelegateBuilder.getServiceGraph());
             appDelegateBuilder.addModule(webServerModuleBuilder.build());
-            final GenericWorkerApp appDelegate = appDelegateBuilder.build();
 
+            final GenericWorkerApp appDelegate = appDelegateBuilder.build();
             super.setLogger(appDelegate.getLogger());
             super.setName(appDelegate.getName());
             super.setServiceConfig(appDelegate.getServiceConfig());

--- a/app-core/src/main/java/net/spals/appbuilder/app/core/matcher/BindingMatchers.java
+++ b/app-core/src/main/java/net/spals/appbuilder/app/core/matcher/BindingMatchers.java
@@ -2,6 +2,7 @@ package net.spals.appbuilder.app.core.matcher;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.inject.Binding;
+import com.google.inject.TypeLiteral;
 import com.google.inject.matcher.AbstractMatcher;
 import com.google.inject.matcher.Matcher;
 import com.google.inject.spi.ElementSource;
@@ -52,6 +53,23 @@ public class BindingMatchers {
         }
     }
 
+    public static Matcher<Binding<?>> withKeyTypeSubclassOf(final Class<?> keyTypeSuperClass) {
+        return new WithKeyTypeSubclassOf(keyTypeSuperClass);
+    }
+
+    private static class WithKeyTypeSubclassOf extends AbstractMatcher<Binding<?>>
+            implements Serializable {
+        private final Matcher<TypeLiteral<?>> subclassOfMatcher;
+
+        private WithKeyTypeSubclassOf(final Class<?> keyTypeSuperClass) {
+            this.subclassOfMatcher = TypeLiteralMatchers.subclassesOf(keyTypeSuperClass);
+        }
+
+        @Override
+        public boolean matches(final Binding<?> binding) {
+            return subclassOfMatcher.matches(binding.getKey().getTypeLiteral());
+        }
+    }
     public static Matcher<Binding<?>> withSourcePackage(final String sourcePackage) {
         return new WithSourcePackage(sourcePackage);
     }

--- a/app-core/src/main/java/net/spals/appbuilder/app/core/modules/AutoBindConfigModule.java
+++ b/app-core/src/main/java/net/spals/appbuilder/app/core/modules/AutoBindConfigModule.java
@@ -22,6 +22,7 @@ import net.spals.appbuilder.config.message.MessageConsumerConfig;
 import net.spals.appbuilder.config.message.MessageProducerConfig;
 import net.spals.appbuilder.config.provider.TypesafeConfigurationProvider;
 import net.spals.appbuilder.config.service.ServiceScan;
+import net.spals.appbuilder.monitor.core.TracerTag;
 import org.inferred.freebuilder.FreeBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -72,6 +73,7 @@ public abstract class AutoBindConfigModule extends AbstractModule {
 
         autoBindConfigs(binder(), MessageConsumerConfig.class, parseConfigs("consumer", MessageConsumerConfig.class));
         autoBindConfigs(binder(), MessageProducerConfig.class, parseConfigs("producer", MessageProducerConfig.class));
+        autoBindConfigs(binder(), TracerTag.class, parseConfigs("tracing", TracerTag.class));
     }
 
     @VisibleForTesting

--- a/app-dropwizard-test/pom.xml
+++ b/app-dropwizard-test/pom.xml
@@ -27,6 +27,10 @@
             <artifactId>dropwizard-testing</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.opentracing</groupId>
+            <artifactId>opentracing-mock</artifactId>
+        </dependency>
+        <dependency>
             <groupId>net.spals.appbuilder</groupId>
             <artifactId>spals-appbuilder-executor-core</artifactId>
         </dependency>

--- a/app-dropwizard-test/pom.xml
+++ b/app-dropwizard-test/pom.xml
@@ -75,6 +75,10 @@
             <artifactId>spals-appbuilder-model-protobuf</artifactId>
         </dependency>
         <dependency>
+            <groupId>net.spals.appbuilder.plugins</groupId>
+            <artifactId>spals-appbuilder-monitor-lightstep</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.hamcrest</groupId>
             <artifactId>java-hamcrest</artifactId>
         </dependency>

--- a/app-dropwizard-test/src/test/java/net/spals/appbuilder/app/dropwizard/MinimalDropwizardWebAppFTest.java
+++ b/app-dropwizard-test/src/test/java/net/spals/appbuilder/app/dropwizard/MinimalDropwizardWebAppFTest.java
@@ -2,13 +2,16 @@ package net.spals.appbuilder.app.dropwizard;
 
 import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.health.HealthCheckRegistry;
+import com.google.inject.ConfigurationException;
 import com.google.inject.Injector;
 import com.google.inject.Key;
 import com.google.inject.TypeLiteral;
 import io.dropwizard.Configuration;
 import io.dropwizard.setup.Environment;
 import io.dropwizard.testing.DropwizardTestSupport;
+import io.opentracing.Tracer;
 import net.spals.appbuilder.app.dropwizard.minimal.MinimalDropwizardWebApp;
+import net.spals.appbuilder.executor.core.ExecutorServiceFactory;
 import org.testng.annotations.AfterTest;
 import org.testng.annotations.BeforeTest;
 import org.testng.annotations.DataProvider;
@@ -16,6 +19,7 @@ import org.testng.annotations.Test;
 
 import javax.validation.Validator;
 
+import static com.googlecode.catchexception.CatchException.verifyException;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
@@ -53,7 +57,7 @@ public class MinimalDropwizardWebAppFTest {
     }
 
     @DataProvider
-    Object[][] defaultServiceInjectorProvider() {
+    Object[][] defaultServiceInjectionProvider() {
         return new Object[][] {
                 {TypeLiteral.get(Environment.class)},
                 {TypeLiteral.get(HealthCheckRegistry.class)},
@@ -62,9 +66,23 @@ public class MinimalDropwizardWebAppFTest {
         } ;
     }
 
-    @Test(dataProvider = "defaultServiceInjectorProvider")
-    public void testDefaultServiceInjector(final TypeLiteral<?> typeLiteral) {
+    @Test(dataProvider = "defaultServiceInjectionProvider")
+    public void testDefaultServiceInjection(final TypeLiteral<?> typeLiteral) {
         final Injector serviceInjector = webAppDelegate.getServiceInjector();
         assertThat(serviceInjector.getInstance(Key.get(typeLiteral)), notNullValue());
+    }
+
+    @DataProvider
+    Object[][] noDefaultServiceInjectionProvider() {
+        return new Object[][] {
+                {TypeLiteral.get(ExecutorServiceFactory.class)},
+                {TypeLiteral.get(Tracer.class)},
+        };
+    }
+
+    @Test(dataProvider = "noDefaultServiceInjectionProvider")
+    public void testNoDefaultServiceInjection(final TypeLiteral<?> typeLiteral) {
+        final Injector serviceInjector = webAppDelegate.getServiceInjector();
+        verifyException(() -> serviceInjector.getInstance(Key.get(typeLiteral)), ConfigurationException.class);
     }
 }

--- a/app-dropwizard-test/src/test/java/net/spals/appbuilder/app/dropwizard/MinimalDropwizardWebAppFTest.java
+++ b/app-dropwizard-test/src/test/java/net/spals/appbuilder/app/dropwizard/MinimalDropwizardWebAppFTest.java
@@ -12,8 +12,8 @@ import io.dropwizard.testing.DropwizardTestSupport;
 import io.opentracing.Tracer;
 import net.spals.appbuilder.app.dropwizard.minimal.MinimalDropwizardWebApp;
 import net.spals.appbuilder.executor.core.ExecutorServiceFactory;
-import org.testng.annotations.AfterTest;
-import org.testng.annotations.BeforeTest;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
@@ -35,13 +35,13 @@ public class MinimalDropwizardWebAppFTest {
             new DropwizardTestSupport<>(MinimalDropwizardWebApp.class, new Configuration());
     private DropwizardWebApp webAppDelegate;
 
-    @BeforeTest
+    @BeforeClass
     void classSetup() {
         testServerWrapper.before();
         webAppDelegate = ((MinimalDropwizardWebApp)testServerWrapper.getApplication()).getDelegate();
     }
 
-    @AfterTest
+    @AfterClass
     void classTearDown() {
         testServerWrapper.after();
     }

--- a/app-dropwizard-test/src/test/java/net/spals/appbuilder/app/dropwizard/PluginsDropwizardWebAppFTest.java
+++ b/app-dropwizard-test/src/test/java/net/spals/appbuilder/app/dropwizard/PluginsDropwizardWebAppFTest.java
@@ -21,8 +21,8 @@ import net.spals.appbuilder.message.core.producer.MessageProducerPlugin;
 import net.spals.appbuilder.model.core.ModelSerializer;
 import net.spals.appbuilder.monitor.core.TracerPlugin;
 import net.spals.appbuilder.monitor.core.TracerTag;
-import org.testng.annotations.AfterTest;
-import org.testng.annotations.BeforeTest;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 import java.util.Map;
@@ -41,13 +41,13 @@ public class PluginsDropwizardWebAppFTest {
             new DropwizardTestSupport<>(PluginsDropwizardWebApp.class, PluginsDropwizardWebApp.APP_CONFIG_FILE_NAME);
     private DropwizardWebApp webAppDelegate;
 
-    @BeforeTest
+    @BeforeClass
     void classSetup() {
         testServerWrapper.before();
         webAppDelegate = ((PluginsDropwizardWebApp)testServerWrapper.getApplication()).getDelegate();
     }
 
-    @AfterTest
+    @AfterClass
     void classTearDown() {
         testServerWrapper.after();
     }

--- a/app-dropwizard-test/src/test/java/net/spals/appbuilder/app/dropwizard/PluginsDropwizardWebAppFTest.java
+++ b/app-dropwizard-test/src/test/java/net/spals/appbuilder/app/dropwizard/PluginsDropwizardWebAppFTest.java
@@ -2,12 +2,13 @@ package net.spals.appbuilder.app.dropwizard;
 
 import com.amazonaws.services.dynamodbv2.AmazonDynamoDB;
 import com.datastax.driver.core.Cluster;
-import com.datastax.driver.core.Session;
 import com.google.inject.Injector;
 import com.google.inject.Key;
 import com.google.inject.TypeLiteral;
 import io.dropwizard.Configuration;
 import io.dropwizard.testing.DropwizardTestSupport;
+import io.opentracing.NoopTracer;
+import io.opentracing.Tracer;
 import net.spals.appbuilder.app.dropwizard.plugins.PluginsDropwizardWebApp;
 import net.spals.appbuilder.filestore.core.FileStore;
 import net.spals.appbuilder.filestore.core.FileStorePlugin;
@@ -18,12 +19,13 @@ import net.spals.appbuilder.message.core.MessageProducer;
 import net.spals.appbuilder.message.core.consumer.MessageConsumerPlugin;
 import net.spals.appbuilder.message.core.producer.MessageProducerPlugin;
 import net.spals.appbuilder.model.core.ModelSerializer;
+import net.spals.appbuilder.monitor.core.TracerPlugin;
+import net.spals.appbuilder.monitor.core.TracerTag;
 import org.testng.annotations.AfterTest;
 import org.testng.annotations.BeforeTest;
 import org.testng.annotations.Test;
 
 import java.util.Map;
-import java.util.concurrent.FutureTask;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
@@ -132,5 +134,34 @@ public class PluginsDropwizardWebAppFTest {
         assertThat(modelSerializerMap, aMapWithSize(2));
         assertThat(modelSerializerMap, hasKey("pojo"));
         assertThat(modelSerializerMap, hasKey("protobuf"));
+    }
+
+    @Test
+    public void testTracerInjection() {
+        final Injector serviceInjector = webAppDelegate.getServiceInjector();
+        assertThat(serviceInjector.getInstance(Tracer.class), instanceOf(NoopTracer.class));
+
+        final TypeLiteral<Map<String, TracerPlugin>> tracerPluginMapKey =
+                new TypeLiteral<Map<String, TracerPlugin>>(){};
+        final Map<String, TracerPlugin> tracerPluginMap =
+                serviceInjector.getInstance(Key.get(tracerPluginMapKey));
+        assertThat(tracerPluginMap, aMapWithSize(2));
+        assertThat(tracerPluginMap, hasKey("lightstep"));
+        assertThat(tracerPluginMap, hasKey("noop"));
+    }
+
+    @Test
+    public void testTracerTagInjection() {
+        final Injector serviceInjector = webAppDelegate.getServiceInjector();
+
+        final TypeLiteral<Map<String, TracerTag>> tracerTagMapKey =
+                new TypeLiteral<Map<String, TracerTag>>(){};
+        final Map<String, TracerTag> tracerTagMap =
+                serviceInjector.getInstance(Key.get(tracerTagMapKey));
+        assertThat(tracerTagMap, aMapWithSize(2));
+        assertThat(tracerTagMap, hasEntry(is("key1"),
+            is(new TracerTag.Builder().setTag("key1").setValue("value").build())));
+        assertThat(tracerTagMap, hasEntry(is("key2"),
+            is(new TracerTag.Builder().setTag("key2").setValue(2).build())));
     }
 }

--- a/app-dropwizard-test/src/test/java/net/spals/appbuilder/app/dropwizard/SampleDropwizardWebAppFTest.java
+++ b/app-dropwizard-test/src/test/java/net/spals/appbuilder/app/dropwizard/SampleDropwizardWebAppFTest.java
@@ -7,6 +7,8 @@ import com.google.inject.name.Names;
 import com.typesafe.config.Config;
 import io.dropwizard.Configuration;
 import io.dropwizard.testing.DropwizardTestSupport;
+import io.opentracing.NoopTracer;
+import io.opentracing.Tracer;
 import net.spals.appbuilder.app.dropwizard.sample.SampleDropwizardCustomService;
 import net.spals.appbuilder.app.dropwizard.sample.SampleDropwizardWebApp;
 import net.spals.appbuilder.executor.core.ExecutorServiceFactory;
@@ -168,5 +170,11 @@ public class SampleDropwizardWebAppFTest {
                 serviceInjector.getInstance(Key.get(modelSerializerMapKey));
         assertThat(modelSerializerMap, aMapWithSize(1));
         assertThat(modelSerializerMap, hasKey("pojo"));
+    }
+
+    @Test
+    public void testMonitorInjection() {
+        final Injector serviceInjector = webAppDelegate.getServiceInjector();
+        assertThat(serviceInjector.getInstance(Tracer.class), instanceOf(NoopTracer.class));
     }
 }

--- a/app-dropwizard-test/src/test/java/net/spals/appbuilder/app/dropwizard/SampleDropwizardWebAppFTest.java
+++ b/app-dropwizard-test/src/test/java/net/spals/appbuilder/app/dropwizard/SampleDropwizardWebAppFTest.java
@@ -22,8 +22,8 @@ import net.spals.appbuilder.message.core.MessageProducer;
 import net.spals.appbuilder.message.core.consumer.MessageConsumerPlugin;
 import net.spals.appbuilder.message.core.producer.MessageProducerPlugin;
 import net.spals.appbuilder.model.core.ModelSerializer;
-import org.testng.annotations.AfterTest;
-import org.testng.annotations.BeforeTest;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
@@ -44,13 +44,13 @@ public class SampleDropwizardWebAppFTest {
             new DropwizardTestSupport<>(SampleDropwizardWebApp.class, SampleDropwizardWebApp.APP_CONFIG_FILE_NAME);
     private DropwizardWebApp webAppDelegate;
 
-    @BeforeTest
+    @BeforeClass
     void classSetup() {
         testServerWrapper.before();
         webAppDelegate = ((SampleDropwizardWebApp)testServerWrapper.getApplication()).getDelegate();
     }
 
-    @AfterTest
+    @AfterClass
     void classTearDown() {
         testServerWrapper.after();
     }

--- a/app-dropwizard-test/src/test/java/net/spals/appbuilder/app/dropwizard/TracingDropwizardWebAppFTest.java
+++ b/app-dropwizard-test/src/test/java/net/spals/appbuilder/app/dropwizard/TracingDropwizardWebAppFTest.java
@@ -1,0 +1,80 @@
+package net.spals.appbuilder.app.dropwizard;
+
+import io.dropwizard.Configuration;
+import io.dropwizard.testing.DropwizardTestSupport;
+import io.opentracing.mock.MockSpan;
+import io.opentracing.mock.MockTracer;
+import net.spals.appbuilder.app.dropwizard.tracing.TracingDropwizardWebApp;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import javax.ws.rs.client.Client;
+import javax.ws.rs.client.ClientBuilder;
+import javax.ws.rs.client.WebTarget;
+import java.util.List;
+import java.util.Optional;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+
+/**
+ * Functional tests for a minimal {@link DropwizardWebApp}
+ *
+ * @author tkral
+ */
+public class TracingDropwizardWebAppFTest {
+
+    private final DropwizardTestSupport<Configuration> testServerWrapper =
+            new DropwizardTestSupport<>(TracingDropwizardWebApp.class, new Configuration());
+    private MockTracer mockTracer;
+
+    private final Client webClient = ClientBuilder.newClient();
+
+    @BeforeClass
+    void classSetup() {
+        testServerWrapper.before();
+        mockTracer = ((TracingDropwizardWebApp)testServerWrapper.getApplication()).getMockTracer();
+    }
+
+    @AfterClass
+    void classTearDown() {
+        testServerWrapper.after();
+    }
+
+    @DataProvider
+    Object[][] serverRequestTracingProvider() {
+        return new Object[][] {
+                {"tracing/noAnnotation", "tracing/noAnnotation"},
+                {"tracing/withAnnotation", "customOperationName"},
+        };
+    }
+
+    @Test(dataProvider = "serverRequestTracingProvider")
+    public void testServerRequestTracing(final String path,
+                                         final String expectedOperationName) {
+        final String target = "http://localhost:" + testServerWrapper.getLocalPort() + "/" + path;
+        final WebTarget webTarget = webClient.target(target);
+        webTarget.request().get();
+
+        final MockSpan mockSpan = findMockSpan(expectedOperationName);
+        assertThat(mockSpan.generatedErrors(), empty());
+        assertThat(mockSpan.tags(), hasEntry("http.method", "GET"));
+        assertThat(mockSpan.tags(), hasEntry("http.status_code", 200));
+        assertThat(mockSpan.tags(), hasEntry("http.url", target));
+        assertThat(mockSpan.tags(), hasEntry("span.kind", "server"));
+    }
+
+    private MockSpan findMockSpan(final String expectedOperationName) {
+        final List<MockSpan> finishedSpans = mockTracer.finishedSpans();
+        assertThat("No finished spans found.", finishedSpans, hasSize(greaterThan(0)));
+
+        final Optional<MockSpan> mockSpan = finishedSpans.stream()
+                .filter(span -> expectedOperationName.equals(span.operationName()))
+                .findAny();
+        assertThat("Could not find span with operationName '" + expectedOperationName + "'",
+                mockSpan, not(Optional.empty()));
+        return mockSpan.get();
+    }
+}

--- a/app-dropwizard-test/src/test/java/net/spals/appbuilder/app/dropwizard/minimal/MinimalDropwizardWebApp.java
+++ b/app-dropwizard-test/src/test/java/net/spals/appbuilder/app/dropwizard/minimal/MinimalDropwizardWebApp.java
@@ -11,7 +11,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * A minimally viable [[DropwizardWebApp]]
+ * A minimally viable {@link DropwizardWebApp}
  *
  * @author tkral
  */

--- a/app-dropwizard-test/src/test/java/net/spals/appbuilder/app/dropwizard/plugins/PluginsDropwizardWebApp.java
+++ b/app-dropwizard-test/src/test/java/net/spals/appbuilder/app/dropwizard/plugins/PluginsDropwizardWebApp.java
@@ -17,7 +17,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * A [[DropwizardWebApp]] which uses all various service plugins.
+ * A {@link DropwizardWebApp} which uses all various service plugins.
  *
  * @author tkral
  */

--- a/app-dropwizard-test/src/test/java/net/spals/appbuilder/app/dropwizard/plugins/PluginsDropwizardWebApp.java
+++ b/app-dropwizard-test/src/test/java/net/spals/appbuilder/app/dropwizard/plugins/PluginsDropwizardWebApp.java
@@ -5,6 +5,7 @@ import io.dropwizard.Application;
 import io.dropwizard.Configuration;
 import io.dropwizard.setup.Bootstrap;
 import io.dropwizard.setup.Environment;
+import io.opentracing.Tracer;
 import net.spals.appbuilder.app.dropwizard.DropwizardWebApp;
 import net.spals.appbuilder.config.service.ServiceScan;
 import net.spals.appbuilder.filestore.core.FileStore;
@@ -51,6 +52,7 @@ public class PluginsDropwizardWebApp extends Application<Configuration> {
                 .addServicePlugins("net.spals.appbuilder.message.kafka", MessageConsumer.class, MessageProducer.class)
                 .addServicePlugins("net.spals.appbuilder.message.kinesis", MessageConsumer.class, MessageProducer.class)
                 .addServicePlugins("net.spals.appbuilder.model.protobuf", ModelSerializer.class)
+                .addServicePlugins("net.spals.appbuilder.monitor.lightstep", Tracer.class)
                 .build());
     }
 

--- a/app-dropwizard-test/src/test/java/net/spals/appbuilder/app/dropwizard/plugins/PluginsDropwizardWebApp.java
+++ b/app-dropwizard-test/src/test/java/net/spals/appbuilder/app/dropwizard/plugins/PluginsDropwizardWebApp.java
@@ -7,7 +7,6 @@ import io.dropwizard.setup.Bootstrap;
 import io.dropwizard.setup.Environment;
 import net.spals.appbuilder.app.dropwizard.DropwizardWebApp;
 import net.spals.appbuilder.config.service.ServiceScan;
-import net.spals.appbuilder.executor.core.ExecutorServiceFactory;
 import net.spals.appbuilder.filestore.core.FileStore;
 import net.spals.appbuilder.mapstore.core.MapStore;
 import net.spals.appbuilder.message.core.MessageConsumer;
@@ -46,7 +45,6 @@ public class PluginsDropwizardWebApp extends Application<Configuration> {
             .setServiceConfigFromClasspath(SERVICE_CONFIG_FILE_NAME)
             .setServiceScan(new ServiceScan.Builder()
                 .addServicePackages("net.spals.appbuilder.app.dropwizard.plugins")
-                .addDefaultServices(ExecutorServiceFactory.class)
                 .addServicePlugins("net.spals.appbuilder.filestore.s3", FileStore.class)
                 .addServicePlugins("net.spals.appbuilder.mapstore.cassandra", MapStore.class)
                 .addServicePlugins("net.spals.appbuilder.mapstore.dynamodb", MapStore.class)

--- a/app-dropwizard-test/src/test/java/net/spals/appbuilder/app/dropwizard/sample/SampleDropwizardWebApp.java
+++ b/app-dropwizard-test/src/test/java/net/spals/appbuilder/app/dropwizard/sample/SampleDropwizardWebApp.java
@@ -16,7 +16,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * A full sample [[DropwizardWebApp]] which uses all default services
+ * A full sample {@link DropwizardWebApp} which uses all default services
  * and bindings.
  *
  * @author tkral

--- a/app-dropwizard-test/src/test/java/net/spals/appbuilder/app/dropwizard/sample/SampleDropwizardWebApp.java
+++ b/app-dropwizard-test/src/test/java/net/spals/appbuilder/app/dropwizard/sample/SampleDropwizardWebApp.java
@@ -7,7 +7,6 @@ import io.dropwizard.setup.Bootstrap;
 import io.dropwizard.setup.Environment;
 import net.spals.appbuilder.app.dropwizard.DropwizardWebApp;
 import net.spals.appbuilder.config.service.ServiceScan;
-import net.spals.appbuilder.executor.core.ExecutorServiceFactory;
 import net.spals.appbuilder.filestore.core.FileStore;
 import net.spals.appbuilder.mapstore.core.MapStore;
 import net.spals.appbuilder.message.core.MessageConsumer;
@@ -47,7 +46,6 @@ public class SampleDropwizardWebApp extends Application<Configuration> {
             .setServiceConfigFromClasspath(SERVICE_CONFIG_FILE_NAME)
             .setServiceScan(new ServiceScan.Builder()
                 .addServicePackages("net.spals.appbuilder.app.dropwizard.sample")
-                .addDefaultServices(ExecutorServiceFactory.class)
                 .addDefaultServices(FileStore.class)
                 .addDefaultServices(MapStore.class)
                 .addDefaultServices(MessageConsumer.class, MessageProducer.class)

--- a/app-dropwizard-test/src/test/java/net/spals/appbuilder/app/dropwizard/tracing/TracingDropwizardResource.java
+++ b/app-dropwizard-test/src/test/java/net/spals/appbuilder/app/dropwizard/tracing/TracingDropwizardResource.java
@@ -1,0 +1,33 @@
+package net.spals.appbuilder.app.dropwizard.tracing;
+
+import io.opentracing.contrib.jaxrs2.server.Traced;
+import net.spals.appbuilder.annotations.service.AutoBindSingleton;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.core.Response;
+
+/**
+ * A sample web resource.
+ *
+ * @author tkral
+ */
+@AutoBindSingleton
+@Path("tracing")
+public class TracingDropwizardResource {
+
+    TracingDropwizardResource() { }
+
+    @GET
+    @Path("noAnnotation")
+    public Response getTracingNoAnnotation() {
+        return Response.ok().build();
+    }
+
+    @GET
+    @Path("withAnnotation")
+    @Traced(operationName = "customOperationName")
+    public Response getTracingWithAnnotation() {
+        return Response.ok().build();
+    }
+}

--- a/app-dropwizard-test/src/test/java/net/spals/appbuilder/app/dropwizard/tracing/TracingDropwizardWebApp.java
+++ b/app-dropwizard-test/src/test/java/net/spals/appbuilder/app/dropwizard/tracing/TracingDropwizardWebApp.java
@@ -1,0 +1,55 @@
+package net.spals.appbuilder.app.dropwizard.tracing;
+
+import com.google.common.annotations.VisibleForTesting;
+import io.dropwizard.Application;
+import io.dropwizard.Configuration;
+import io.dropwizard.setup.Bootstrap;
+import io.dropwizard.setup.Environment;
+import io.opentracing.Tracer;
+import io.opentracing.mock.MockTracer;
+import net.spals.appbuilder.app.dropwizard.DropwizardWebApp;
+import net.spals.appbuilder.config.service.ServiceScan;
+import net.spals.appbuilder.filestore.core.FileStore;
+import net.spals.appbuilder.mapstore.core.MapStore;
+import net.spals.appbuilder.message.core.MessageConsumer;
+import net.spals.appbuilder.message.core.MessageProducer;
+import net.spals.appbuilder.model.core.ModelSerializer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * A minimally viable {@link DropwizardWebApp}
+ *
+ * @author tkral
+ */
+public class TracingDropwizardWebApp extends Application<Configuration> {
+    private static final Logger LOGGER = LoggerFactory.getLogger(TracingDropwizardWebApp.class);
+
+    public static void main(final String[] args) throws Throwable {
+        new TracingDropwizardWebApp().run("server");
+    }
+
+    private DropwizardWebApp.Builder webAppDelegateBuilder;
+    private final MockTracer mockTracer = new MockTracer();
+
+    @VisibleForTesting
+    public MockTracer getMockTracer() {
+        return mockTracer;
+    }
+
+    @Override
+    public void initialize(final Bootstrap<Configuration> bootstrap) {
+        this.webAppDelegateBuilder = new DropwizardWebApp.Builder(bootstrap, LOGGER)
+                .setServiceScan(new ServiceScan.Builder()
+                        .addServicePackages("net.spals.appbuilder.app.dropwizard.tracing")
+                        .build())
+                .addModule(binder -> binder.bind(Tracer.class).toInstance(mockTracer))
+                // Allow the mock tracer to override the real tracer instance
+                .enableBindingOverrides();
+    }
+
+    @Override
+    public void run(Configuration configuration, Environment env) throws Exception {
+        webAppDelegateBuilder.setEnvironment(env).build();
+    }
+}

--- a/app-dropwizard-test/src/test/resources/config/plugins-dropwizard-service.conf
+++ b/app-dropwizard-test/src/test/resources/config/plugins-dropwizard-service.conf
@@ -61,3 +61,13 @@ kinesisNotifications.producer.channel="notifications"
 kinesisNotifications.producer.format="protobuf"
 kinesisNotifications.producer.globalId="plugins-kinesis-notifications-producer"
 kinesisNotifications.producer.destination="kinesis"
+
+### Tracing configuration ###
+tracing.system="noop"
+
+key1.tracing.tagValue="value"
+key2.tracing.tagValue=2
+
+tracing.lightstep.accessToken="123abc"
+tracing.lightstep.collectorHost="192.168.0.5"
+tracing.lightstep.collectorPort=1234

--- a/app-finatra-test/pom.xml
+++ b/app-finatra-test/pom.xml
@@ -100,6 +100,10 @@
             <artifactId>spals-appbuilder-model-protobuf</artifactId>
         </dependency>
         <dependency>
+            <groupId>net.spals.appbuilder.plugins</groupId>
+            <artifactId>spals-appbuilder-monitor-lightstep</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.hamcrest</groupId>
             <artifactId>java-hamcrest</artifactId>
         </dependency>

--- a/app-finatra-test/src/test/resources/config/plugins-finatra-service.conf
+++ b/app-finatra-test/src/test/resources/config/plugins-finatra-service.conf
@@ -61,3 +61,13 @@ kinesisNotifications.producer.channel="notifications"
 kinesisNotifications.producer.format="protobuf"
 kinesisNotifications.producer.globalId="plugins-kinesis-notifications-producer"
 kinesisNotifications.producer.destination="kinesis"
+
+### Tracing configuration ###
+tracing.system="noop"
+
+key1.tracing.tagValue="value"
+key2.tracing.tagValue=2
+
+tracing.lightstep.accessToken="123abc"
+tracing.lightstep.collectorHost="192.168.0.5"
+tracing.lightstep.collectorPort=1234

--- a/app-finatra-test/src/test/scala/net/spals/appbuilder/app/finatra/SampleFinatraWebAppFTest.scala
+++ b/app-finatra-test/src/test/scala/net/spals/appbuilder/app/finatra/SampleFinatraWebAppFTest.scala
@@ -4,6 +4,7 @@ import com.google.inject.name.Names
 import com.google.inject.{Key, Stage, TypeLiteral}
 import com.twitter.finatra.http.EmbeddedHttpServer
 import com.twitter.inject.annotations.FlagImpl
+import io.opentracing.{NoopTracer, Tracer}
 import net.spals.appbuilder.app.finatra.sample.web.{SampleFinatraController, SampleFinatraExceptionMapper, SampleFinatraFilter}
 import net.spals.appbuilder.app.finatra.sample.{SampleFinatraCustomService, SampleFinatraWebApp}
 import net.spals.appbuilder.executor.core.ExecutorServiceFactory
@@ -15,7 +16,7 @@ import net.spals.appbuilder.message.core.{MessageConsumer, MessageConsumerCallba
 import net.spals.appbuilder.model.core.ModelSerializer
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers
-import org.hamcrest.Matchers.{hasKey, is, notNullValue}
+import org.hamcrest.Matchers.{hasKey, instanceOf, is, notNullValue}
 import org.mockito.ArgumentMatchers.{any, isA}
 import org.mockito.Mockito.verify
 import org.testng.annotations.{AfterClass, BeforeClass, DataProvider, Test}
@@ -142,6 +143,11 @@ class SampleFinatraWebAppFTest {
     val modelSerializerMap = serviceInjector.getInstance(Key.get(modelSerializerMapKey))
     assertThat(modelSerializerMap, Matchers.aMapWithSize[String, ModelSerializer](1))
     assertThat(modelSerializerMap, hasKey("pojo"))
+  }
+
+  @Test def testMonitorInjection() {
+    val serviceInjector = sampleApp.getServiceInjector
+    assertThat(serviceInjector.getInstance(classOf[Tracer]), instanceOf[Tracer](classOf[NoopTracer]))
   }
 
   @Test def testWebControllerInjection() {

--- a/app-finatra-test/src/test/scala/net/spals/appbuilder/app/finatra/plugins/PluginsFinatraWebApp.scala
+++ b/app-finatra-test/src/test/scala/net/spals/appbuilder/app/finatra/plugins/PluginsFinatraWebApp.scala
@@ -2,7 +2,6 @@ package net.spals.appbuilder.app.finatra.plugins
 
 import net.spals.appbuilder.app.finatra.FinatraWebApp
 import net.spals.appbuilder.config.service.ServiceScan
-import net.spals.appbuilder.executor.core.ExecutorServiceFactory
 import net.spals.appbuilder.filestore.core.FileStore
 import net.spals.appbuilder.mapstore.core.MapStore
 import net.spals.appbuilder.message.core.{MessageConsumer, MessageProducer}
@@ -20,7 +19,6 @@ private[finatra] class PluginsFinatraWebApp extends FinatraWebApp {
   setServiceConfigFromClasspath("config/plugins-finatra-service.conf")
   setServiceScan(new ServiceScan.Builder()
     .addServicePackages("net.spals.appbuilder.app.finatra.plugins")
-    .addDefaultServices(classOf[ExecutorServiceFactory])
     .addServicePlugins("net.spals.appbuilder.filestore.s3", classOf[FileStore])
     .addServicePlugins("net.spals.appbuilder.mapstore.cassandra", classOf[MapStore])
     .addServicePlugins("net.spals.appbuilder.mapstore.dynamodb", classOf[MapStore])

--- a/app-finatra-test/src/test/scala/net/spals/appbuilder/app/finatra/plugins/PluginsFinatraWebApp.scala
+++ b/app-finatra-test/src/test/scala/net/spals/appbuilder/app/finatra/plugins/PluginsFinatraWebApp.scala
@@ -1,5 +1,6 @@
 package net.spals.appbuilder.app.finatra.plugins
 
+import io.opentracing.Tracer
 import net.spals.appbuilder.app.finatra.FinatraWebApp
 import net.spals.appbuilder.config.service.ServiceScan
 import net.spals.appbuilder.filestore.core.FileStore
@@ -25,6 +26,7 @@ private[finatra] class PluginsFinatraWebApp extends FinatraWebApp {
     .addServicePlugins("net.spals.appbuilder.message.kafka", classOf[MessageConsumer], classOf[MessageProducer])
     .addServicePlugins("net.spals.appbuilder.message.kinesis", classOf[MessageConsumer], classOf[MessageProducer])
     .addServicePlugins("net.spals.appbuilder.model.protobuf", classOf[ModelSerializer])
+    .addServicePlugins("net.spals.appbuilder.monitor.lightstep", classOf[Tracer])
     .build())
   build()
 

--- a/app-finatra-test/src/test/scala/net/spals/appbuilder/app/finatra/sample/SampleFinatraWebApp.scala
+++ b/app-finatra-test/src/test/scala/net/spals/appbuilder/app/finatra/sample/SampleFinatraWebApp.scala
@@ -3,7 +3,6 @@ package net.spals.appbuilder.app.finatra.sample
 import com.twitter.finatra.http.routing.HttpRouter
 import net.spals.appbuilder.app.finatra.FinatraWebApp
 import net.spals.appbuilder.config.service.ServiceScan
-import net.spals.appbuilder.executor.core.ExecutorServiceFactory
 import net.spals.appbuilder.filestore.core.FileStore
 import net.spals.appbuilder.mapstore.core.MapStore
 import net.spals.appbuilder.message.core.{MessageConsumer, MessageProducer}
@@ -25,7 +24,6 @@ private[finatra] class SampleFinatraWebApp extends FinatraWebApp {
   setServiceConfigFromClasspath("config/sample-finatra-service.conf")
   setServiceScan(new ServiceScan.Builder()
     .addServicePackages("net.spals.appbuilder.app.finatra.sample")
-    .addDefaultServices(classOf[ExecutorServiceFactory])
     .addDefaultServices(classOf[FileStore])
     .addDefaultServices(classOf[MapStore])
     .addDefaultServices(classOf[MessageConsumer], classOf[MessageProducer])

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -63,6 +63,10 @@
             <artifactId>spals-appbuilder-model-core</artifactId>
         </dependency>
         <dependency>
+            <groupId>net.spals.appbuilder</groupId>
+            <artifactId>spals-appbuilder-monitor-core</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.reflections</groupId>
             <artifactId>reflections</artifactId>
         </dependency>

--- a/config/src/main/java/net/spals/appbuilder/config/service/ServiceScan.java
+++ b/config/src/main/java/net/spals/appbuilder/config/service/ServiceScan.java
@@ -36,6 +36,16 @@ public interface ServiceScan {
 
         public Builder() {
             setReflections(EMPTY_REFLECTIONS);
+            // Executor and monitoring services are special because they
+            // are used widely throughout the framework in several modules.
+            // As such, the service scan will guarantee that core executor
+            // and monitoring services are always injected without the
+            // application author having to do so manually. However, they
+            // will have to install plugins manually
+            addServicePackages(
+                "net.spals.appbuilder.executor.core",
+                "net.spals.appbuilder.monitor.core"
+            );
         }
 
         public Builder addDefaultServices(final Class<?> serviceClass) {

--- a/executor-core/pom.xml
+++ b/executor-core/pom.xml
@@ -19,6 +19,10 @@
             <artifactId>governator-api</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.opentracing.contrib</groupId>
+            <artifactId>opentracing-concurrent</artifactId>
+        </dependency>
+        <dependency>
             <groupId>net.spals.appbuilder</groupId>
             <artifactId>spals-appbuilder-annotations</artifactId>
         </dependency>

--- a/executor-core/src/main/java/net/spals/appbuilder/executor/core/DefaultExecutorServiceFactory.java
+++ b/executor-core/src/main/java/net/spals/appbuilder/executor/core/DefaultExecutorServiceFactory.java
@@ -1,6 +1,9 @@
 package net.spals.appbuilder.executor.core;
 
+import com.google.inject.Inject;
 import com.netflix.governator.annotations.Configuration;
+import io.opentracing.Tracer;
+import io.opentracing.contrib.concurrent.TracedExecutorService;
 import net.spals.appbuilder.annotations.service.AutoBindSingleton;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -27,51 +30,65 @@ class DefaultExecutorServiceFactory implements ExecutorServiceFactory {
     @Configuration("executorService.registry.shutdownUnit")
     private volatile TimeUnit shutdownUnit = TimeUnit.MILLISECONDS;
 
-    private final Map<Key, DelegatingManagedExecutorService> managedExecutorServices = new HashMap<>();
+    private final Map<Key, StoppableExecutorService> stoppableExecutorServices = new HashMap<>();
+    private final Tracer tracer;
+
+    @Inject
+    DefaultExecutorServiceFactory(final Tracer tracer) {
+        this.tracer = tracer;
+    }
 
     @Override
     public ExecutorService createFixedThreadPool(final int nThreads,
-                                                 final Class<?> parentClass,
-                                                 final String... tags) {
-        final Key key = new Key.Builder().setParentClass(parentClass).addTags(tags).build();
-        final DelegatingManagedExecutorService managedExecutorService =
-                new DelegatingManagedExecutorService(Executors.newFixedThreadPool(nThreads), key, shutdown, shutdownUnit);
+                                                 final Key key) {
+        final ExecutorService delegate = Executors.newFixedThreadPool(nThreads);
 
-        LOGGER.info("Created FixedThreadPool executor service for " + key.getParentClass().getSimpleName() +
-                "(" + key.getTags() + ")");
-        managedExecutorServices.put(key, managedExecutorService);
-        return managedExecutorService;
+        final StoppableExecutorService stoppableExecutorService = decorateExecutorService(delegate, key);
+        logExecutorService("FixedThreadPool", key);
+        stoppableExecutorServices.put(key, stoppableExecutorService);
+        return stoppableExecutorService;
     }
 
     @Override
-    public ExecutorService createCachedThreadPool(final Class<?> parentClass,
-                                                  final String... tags) {
-        final Key key = new Key.Builder().setParentClass(parentClass).addTags(tags).build();
-        final DelegatingManagedExecutorService managedExecutorService =
-                new DelegatingManagedExecutorService(Executors.newCachedThreadPool(), key, shutdown, shutdownUnit);
+    public ExecutorService createCachedThreadPool(final Key key) {
+        final ExecutorService delegate = Executors.newCachedThreadPool();
 
-        LOGGER.info("Created CachedThreadPool executor service for " + key.getParentClass().getSimpleName() +
-                "(" + key.getTags() + ")");
-        managedExecutorServices.put(key, managedExecutorService);
-        return managedExecutorService;
+        final StoppableExecutorService stoppableExecutorService = decorateExecutorService(delegate, key);
+        logExecutorService("CachedThreadPool", key);
+        stoppableExecutorServices.put(key, stoppableExecutorService);
+        return stoppableExecutorService;
     }
 
     @Override
-    public ExecutorService createSingleThreadExecutor(final Class<?> parentClass,
-                                                      final String... tags) {
-        final Key key = new Key.Builder().setParentClass(parentClass).addTags(tags).build();
-        final DelegatingManagedExecutorService managedExecutorService =
-                new DelegatingManagedExecutorService(Executors.newSingleThreadExecutor(), key, shutdown, shutdownUnit);
+    public ExecutorService createSingleThreadExecutor(final Key key) {
+        final ExecutorService delegate = Executors.newSingleThreadExecutor();
 
-        LOGGER.info("Created SingleThreadExecutor executor service for " + key.getParentClass().getSimpleName() +
+        final StoppableExecutorService stoppableExecutorService = decorateExecutorService(delegate, key);
+        logExecutorService("SingleThreadExecutor", key);
+        stoppableExecutorServices.put(key, stoppableExecutorService);
+        return stoppableExecutorService;
+    }
+
+    StoppableExecutorService decorateExecutorService(final ExecutorService delegate,
+                                                     final Key key) {
+        // First, wrap the delegate as a traced executor service so we get nice asynchronous tracing
+        final ExecutorService tracedExecutorService = new TracedExecutorService(delegate, tracer);
+        // Second, wrap the delegate as a stoppable executor service so we can gracefully shutdown
+        // at the end of the application's life
+        final StoppableExecutorService stoppableExecutorService =
+                new StoppableExecutorService(tracedExecutorService, key, shutdown, shutdownUnit);
+
+        return stoppableExecutorService;
+    }
+
+    void logExecutorService(final String description, final Key key) {
+        LOGGER.info("Created " + description + " executor service for " + key.getParentClass().getSimpleName() +
                 "(" + key.getTags() + ")");
-        managedExecutorServices.put(key, managedExecutorService);
-        return managedExecutorService;
     }
 
     @PreDestroy
     public synchronized void stop() {
-        managedExecutorServices.entrySet()
+        stoppableExecutorServices.entrySet()
                 .forEach(entry -> {
                     LOGGER.info("Shutting down ExecutorService for " +
                             entry.getKey().getParentClass().getSimpleName() + "(" + entry.getKey().getTags() + ")");

--- a/executor-core/src/main/java/net/spals/appbuilder/executor/core/ExecutorServiceFactory.java
+++ b/executor-core/src/main/java/net/spals/appbuilder/executor/core/ExecutorServiceFactory.java
@@ -11,14 +11,28 @@ import java.util.concurrent.ExecutorService;
 public interface ExecutorServiceFactory {
 
     ExecutorService createFixedThreadPool(int nThreads,
-                                          Class<?> parentClass,
-                                          String... nameSuffixes);
+                                          Key key);
 
-    ExecutorService createCachedThreadPool(Class<?> parentClass,
-                                           String... nameSuffixes);
+    default ExecutorService createFixedThreadPool(int nThreads,
+                                                  Class<?> parentClass,
+                                                  String... tags) {
+        return createFixedThreadPool(nThreads,
+            new Key.Builder().setParentClass(parentClass).addTags(tags).build());
+    }
 
-    ExecutorService createSingleThreadExecutor(Class<?> parentClass,
-                                               String... nameSuffixes);
+    ExecutorService createCachedThreadPool(Key key);
+
+    default ExecutorService createCachedThreadPool(Class<?> parentClass,
+                                                   String... tags) {
+        return createCachedThreadPool(new Key.Builder().setParentClass(parentClass).addTags(tags).build());
+    }
+
+    ExecutorService createSingleThreadExecutor(Key key);
+
+    default ExecutorService createSingleThreadExecutor(Class<?> parentClass,
+                                                       String... tags) {
+        return createSingleThreadExecutor(new Key.Builder().setParentClass(parentClass).addTags(tags).build());
+    }
 
     @FreeBuilder
     interface Key {

--- a/executor-core/src/main/java/net/spals/appbuilder/executor/core/StoppableExecutorService.java
+++ b/executor-core/src/main/java/net/spals/appbuilder/executor/core/StoppableExecutorService.java
@@ -10,12 +10,12 @@ import java.util.concurrent.*;
 
 /**
  * An {@link ExecutorService} delegater which provides
- * a {@link #stop()} method to run a gracefully shutdown
+ * a {@link #stop()} method to run a graceful shutdown
  * of the executor.
  *
  * @author tkral
  */
-class DelegatingManagedExecutorService implements ExecutorService {
+class StoppableExecutorService implements ExecutorService {
 
     private final ExecutorService executorServiceDelegate;
 
@@ -24,10 +24,10 @@ class DelegatingManagedExecutorService implements ExecutorService {
     private final long shutdown;
     private final TimeUnit shutdownUnit;
 
-    DelegatingManagedExecutorService(final ExecutorService executorServiceDelegate,
-                                     final ExecutorServiceFactory.Key executorServiceKey,
-                                     final long shutdown,
-                                     final TimeUnit shutdownUnit) {
+    StoppableExecutorService(final ExecutorService executorServiceDelegate,
+                             final ExecutorServiceFactory.Key executorServiceKey,
+                             final long shutdown,
+                             final TimeUnit shutdownUnit) {
         this.executorServiceDelegate = executorServiceDelegate;
 
         final String loggerName = String.format("%s[%s]", executorServiceKey.getParentClass().getName(),

--- a/filestore-s3-test/pom.xml
+++ b/filestore-s3-test/pom.xml
@@ -27,6 +27,10 @@
             <artifactId>catch-throwable</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.opentracing</groupId>
+            <artifactId>opentracing-mock</artifactId>
+        </dependency>
+        <dependency>
             <groupId>net.spals.appbuilder.plugins</groupId>
             <artifactId>spals-appbuilder-filestore-s3</artifactId>
         </dependency>

--- a/filestore-s3-test/src/test/scala/net/spals/appbuilder/filestore/s3/S3FileStorePluginIT.scala
+++ b/filestore-s3-test/src/test/scala/net/spals/appbuilder/filestore/s3/S3FileStorePluginIT.scala
@@ -47,7 +47,7 @@ class S3FileStorePluginIT {
 
   private lazy val s3TransferManager = {
     val executorServiceFactory = mock(classOf[ExecutorServiceFactory])
-    when(executorServiceFactory.createFixedThreadPool(m_anyInt(), m_any()))
+    when(executorServiceFactory.createFixedThreadPool(m_anyInt(), m_any(classOf[Class[_]])))
       .thenReturn(Executors.newSingleThreadExecutor())
 
     val s3TransferManagerProvider = new S3TransferManagerProvider(s3Client, executorServiceFactory)

--- a/filestore-s3-test/src/test/scala/net/spals/appbuilder/filestore/s3/S3FileStorePluginIT.scala
+++ b/filestore-s3-test/src/test/scala/net/spals/appbuilder/filestore/s3/S3FileStorePluginIT.scala
@@ -10,6 +10,7 @@ import com.amazonaws.services.s3.internal.SkipMd5CheckStrategy._
 import com.amazonaws.services.s3.transfer.TransferManager
 import com.google.common.base.Charsets
 import com.google.common.io.Resources
+import io.opentracing.mock.MockTracer
 import net.spals.appbuilder.executor.core.ExecutorServiceFactory
 import net.spals.appbuilder.filestore.core.model._
 import org.hamcrest.MatcherAssert._
@@ -33,7 +34,7 @@ class S3FileStorePluginIT {
     System.setProperty(DISABLE_GET_OBJECT_MD5_VALIDATION_PROPERTY, "true")
     System.setProperty(DISABLE_PUT_OBJECT_MD5_VALIDATION_PROPERTY, "true")
 
-    val s3ClientProvider = new S3ClientProvider
+    val s3ClientProvider = new S3ClientProvider(new MockTracer())
     s3ClientProvider.awsAccessKeyId = "DUMMY"
     s3ClientProvider.awsSecretKey = "DUMMY"
     s3ClientProvider.endpoint = s"http://${System.getenv("S3_IP")}:${System.getenv("S3_PORT")}"

--- a/filestore-s3/pom.xml
+++ b/filestore-s3/pom.xml
@@ -23,6 +23,10 @@
             <artifactId>governator-api</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.opentracing.contrib</groupId>
+            <artifactId>opentracing-aws-sdk</artifactId>
+        </dependency>
+        <dependency>
             <groupId>javax.validation</groupId>
             <artifactId>validation-api</artifactId>
         </dependency>
@@ -41,6 +45,10 @@
         <dependency>
             <groupId>net.spals.appbuilder</groupId>
             <artifactId>spals-appbuilder-filestore-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>net.spals.appbuilder</groupId>
+            <artifactId>spals-appbuilder-monitor-core</artifactId>
         </dependency>
         <dependency>
             <groupId>org.scala-lang</groupId>

--- a/mapstore-dynamodb-test/pom.xml
+++ b/mapstore-dynamodb-test/pom.xml
@@ -27,6 +27,10 @@
             <artifactId>catch-throwable</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.opentracing</groupId>
+            <artifactId>opentracing-mock</artifactId>
+        </dependency>
+        <dependency>
             <groupId>net.spals.appbuilder.plugins</groupId>
             <artifactId>spals-appbuilder-mapstore-dynamodb</artifactId>
         </dependency>

--- a/mapstore-dynamodb-test/src/test/scala/net/spals/appbuilder/mapstore/dynamodb/DynamoDBMapStorePluginIT.scala
+++ b/mapstore-dynamodb-test/src/test/scala/net/spals/appbuilder/mapstore/dynamodb/DynamoDBMapStorePluginIT.scala
@@ -2,6 +2,7 @@ package net.spals.appbuilder.mapstore.dynamodb
 
 import java.util.Optional
 
+import io.opentracing.mock.MockTracer
 import net.spals.appbuilder.mapstore.core.model.MapQueryOptions.defaultOptions
 import net.spals.appbuilder.mapstore.core.model.SingleValueMapRangeKey._
 import net.spals.appbuilder.mapstore.core.model.TwoValueMapRangeKey.between
@@ -23,7 +24,7 @@ class DynamoDBMapStorePluginIT {
   private val LOGGER = LoggerFactory.getLogger(classOf[DynamoDBMapStorePluginIT])
 
   private lazy val dynamoDBClient = {
-    val dynamoDBClientProvider = new DynamoDBClientProvider
+    val dynamoDBClientProvider = new DynamoDBClientProvider(new MockTracer())
     dynamoDBClientProvider.awsAccessKeyId = "DUMMY"
     dynamoDBClientProvider.awsSecretKey = "DUMMY"
     dynamoDBClientProvider.endpoint = s"http://${System.getenv("DYNAMODB_IP")}:${System.getenv("DYNAMODB_PORT")}"

--- a/mapstore-dynamodb-test/src/test/scala/net/spals/appbuilder/mapstore/dynamodb/DynamoDBMapStorePluginIT.scala
+++ b/mapstore-dynamodb-test/src/test/scala/net/spals/appbuilder/mapstore/dynamodb/DynamoDBMapStorePluginIT.scala
@@ -2,16 +2,18 @@ package net.spals.appbuilder.mapstore.dynamodb
 
 import java.util.Optional
 
-import io.opentracing.mock.MockTracer
+import io.opentracing.mock.{MockSpan, MockTracer}
 import net.spals.appbuilder.mapstore.core.model.MapQueryOptions.defaultOptions
 import net.spals.appbuilder.mapstore.core.model.SingleValueMapRangeKey._
 import net.spals.appbuilder.mapstore.core.model.TwoValueMapRangeKey.between
 import net.spals.appbuilder.mapstore.core.model.ZeroValueMapRangeKey.all
 import net.spals.appbuilder.mapstore.core.model.{MapStoreKey, MapStoreTableKey}
+import net.spals.appbuilder.mapstore.dynamodb.DynamoDBSpanMatcher.dynamoDBSpan
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.{contains, empty, is}
+import org.hamcrest.{Description, Matchers, TypeSafeMatcher}
 import org.slf4j.LoggerFactory
-import org.testng.annotations.{AfterClass, BeforeClass, DataProvider, Test}
+import org.testng.annotations._
 
 import scala.collection.JavaConverters._
 
@@ -23,11 +25,13 @@ import scala.collection.JavaConverters._
 class DynamoDBMapStorePluginIT {
   private val LOGGER = LoggerFactory.getLogger(classOf[DynamoDBMapStorePluginIT])
 
+  private val dynamoDBEndpoint = s"http://${System.getenv("DYNAMODB_IP")}:${System.getenv("DYNAMODB_PORT")}"
+  private val dynamoDBTracer = new MockTracer()
   private lazy val dynamoDBClient = {
-    val dynamoDBClientProvider = new DynamoDBClientProvider(new MockTracer())
+    val dynamoDBClientProvider = new DynamoDBClientProvider(dynamoDBTracer)
     dynamoDBClientProvider.awsAccessKeyId = "DUMMY"
     dynamoDBClientProvider.awsSecretKey = "DUMMY"
-    dynamoDBClientProvider.endpoint = s"http://${System.getenv("DYNAMODB_IP")}:${System.getenv("DYNAMODB_PORT")}"
+    dynamoDBClientProvider.endpoint = dynamoDBEndpoint
 
     LOGGER.info(s"Connecting to dynamoDB instance at ${dynamoDBClientProvider.endpoint}")
     dynamoDBClientProvider.get()
@@ -51,6 +55,10 @@ class DynamoDBMapStorePluginIT {
     mapStorePlugin.createTable(rangeTableName, rangeTableKey)
   }
 
+  @BeforeMethod def resetTracer() {
+    dynamoDBTracer.reset()
+  }
+
   @AfterClass(alwaysRun = true) def dropTables() {
     mapStorePlugin.dropTable(hashTableName)
     mapStorePlugin.dropTable(rangeTableName)
@@ -72,12 +80,14 @@ class DynamoDBMapStorePluginIT {
   def testEmptyGetItem(tableName: String,
                        storeKey: MapStoreKey) {
     assertThat(mapStorePlugin.getItem(tableName, storeKey), is(Optional.empty[java.util.Map[String, AnyRef]]))
+    assertThat(dynamoDBTracer.finishedSpans(), contains[MockSpan](dynamoDBSpan(dynamoDBEndpoint, "POST")))
   }
 
   @Test(dataProvider = "emptyGetProvider")
   def testEmptyGetItems(tableName: String,
                         storeKey: MapStoreKey) {
     assertThat(mapStorePlugin.getItems(tableName, storeKey, defaultOptions()), empty[java.util.Map[String, AnyRef]])
+    assertThat(dynamoDBTracer.finishedSpans(), contains[MockSpan](dynamoDBSpan(dynamoDBEndpoint, "POST")))
   }
 
   @DataProvider def putItemProvider(): Array[Array[AnyRef]] = {
@@ -117,6 +127,8 @@ class DynamoDBMapStorePluginIT {
                   expectedResult: Map[String, AnyRef]) {
     assertThat(mapStorePlugin.putItem(tableName, storeKey, payload.asJava), is(expectedResult.asJava))
     assertThat(mapStorePlugin.getItem(tableName, storeKey), is(Optional.of(expectedResult.asJava)))
+    assertThat(dynamoDBTracer.finishedSpans(),
+      contains[MockSpan](dynamoDBSpan(dynamoDBEndpoint, "POST"), dynamoDBSpan(dynamoDBEndpoint, "POST")))
   }
 
   @DataProvider def updateItemProvider(): Array[Array[AnyRef]] = {
@@ -136,6 +148,8 @@ class DynamoDBMapStorePluginIT {
 
     assertThat(mapStorePlugin.updateItem(rangeTableName, storeKey, payload.asJava), is(expectedResult.asJava))
     assertThat(mapStorePlugin.getItem(rangeTableName, storeKey), is(Optional.of(expectedResult.asJava)))
+    assertThat(dynamoDBTracer.finishedSpans(), contains[MockSpan](dynamoDBSpan(dynamoDBEndpoint, "POST"),
+      dynamoDBSpan(dynamoDBEndpoint, "POST"), dynamoDBSpan(dynamoDBEndpoint, "POST")))
   }
 
   @DataProvider def getItemsProvider(): Array[Array[AnyRef]] = {
@@ -179,5 +193,30 @@ class DynamoDBMapStorePluginIT {
                    expectedResults: List[Map[String, AnyRef]]) {
     assertThat(mapStorePlugin.getItems(rangeTableName, storeKey, defaultOptions()),
       contains[java.util.Map[String, AnyRef]](expectedResults.map(_.asJava): _*))
+    assertThat(dynamoDBTracer.finishedSpans(), contains[MockSpan](dynamoDBSpan(dynamoDBEndpoint, "POST")))
+  }
+}
+
+private object DynamoDBSpanMatcher {
+
+  def dynamoDBSpan(url: String, method: String): DynamoDBSpanMatcher =
+    DynamoDBSpanMatcher(url, method)
+}
+
+private case class DynamoDBSpanMatcher(url: String, method: String) extends TypeSafeMatcher[MockSpan] {
+
+  override def matchesSafely(mockSpan: MockSpan): Boolean = {
+    Matchers.hasEntry[String, AnyRef]("component", "java-aws-sdk").matches(mockSpan.tags()) &&
+      Matchers.hasEntry[String, AnyRef]("http.method", method).matches(mockSpan.tags()) &&
+      Matchers.hasEntry[String, AnyRef]("http.url", url).matches(mockSpan.tags()) &&
+      Matchers.hasEntry[String, AnyRef]("span.kind", "client").matches(mockSpan.tags()) &&
+      "AmazonDynamoDBv2".equals(mockSpan.operationName())
+  }
+
+  override def describeTo(description: Description): Unit = {
+    description.appendText("a DynamoDB span tagged with method ")
+    description.appendText(method)
+    description.appendText(" and url ")
+    description.appendText(url)
   }
 }

--- a/mapstore-dynamodb/pom.xml
+++ b/mapstore-dynamodb/pom.xml
@@ -23,6 +23,10 @@
             <artifactId>governator-api</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.opentracing.contrib</groupId>
+            <artifactId>opentracing-aws-sdk</artifactId>
+        </dependency>
+        <dependency>
             <groupId>javax.validation</groupId>
             <artifactId>validation-api</artifactId>
         </dependency>
@@ -37,6 +41,10 @@
         <dependency>
             <groupId>net.spals.appbuilder</groupId>
             <artifactId>spals-appbuilder-mapstore-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>net.spals.appbuilder</groupId>
+            <artifactId>spals-appbuilder-monitor-core</artifactId>
         </dependency>
         <dependency>
             <groupId>org.scala-lang</groupId>

--- a/monitor-core-test/pom.xml
+++ b/monitor-core-test/pom.xml
@@ -1,0 +1,43 @@
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+    <parent>
+        <groupId>net.spals.appbuilder</groupId>
+        <artifactId>spals-appbuilder-parent</artifactId>
+        <version>0.0.4-SNAPSHOT</version>
+    </parent>
+
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>net.spals.appbuilder</groupId>
+    <artifactId>spals-appbuilder-monitor-core-test</artifactId>
+    <version>0.0.4-SNAPSHOT</version>
+    <packaging>jar</packaging>
+
+    <dependencies>
+        <dependency>
+            <groupId>eu.codearte.catch-exception</groupId>
+            <artifactId>catch-exception</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>eu.codearte.catch-exception</groupId>
+            <artifactId>catch-throwable</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>net.spals.appbuilder</groupId>
+            <artifactId>spals-appbuilder-monitor-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>java-hamcrest</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.testng</groupId>
+            <artifactId>testng</artifactId>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/monitor-core-test/src/test/java/net/spals/appbuilder/monitor/core/TracerProviderTest.java
+++ b/monitor-core-test/src/test/java/net/spals/appbuilder/monitor/core/TracerProviderTest.java
@@ -1,0 +1,54 @@
+package net.spals.appbuilder.monitor.core;
+
+import io.opentracing.NoopTracer;
+import io.opentracing.NoopTracerFactory;
+import io.opentracing.Tracer;
+import io.opentracing.util.GlobalTracer;
+import org.testng.annotations.Test;
+
+import java.util.Collections;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for {@link TracerProvider}
+ *
+ * @author tkral
+ */
+public class TracerProviderTest {
+
+    @Test
+    public void testNoopDefault() {
+        final TracerPlugin tracerPlugin = mock(TracerPlugin.class);
+        when(tracerPlugin.createTracer(anyMap())).thenReturn(NoopTracerFactory.create());
+
+        final TracerProvider tracerProvider = new TracerProvider(
+                Collections.singletonMap("noop", tracerPlugin),
+                Collections.<String, TracerTag>emptyMap()
+        );
+
+        assertThat(tracerProvider.get(), instanceOf(NoopTracer.class));
+    }
+
+    // Run after testNoopDefault because only one GlobalTracer is allowed
+    @Test(dependsOnMethods = "testNoopDefault")
+    public void testGlobalTracerRegistration() {
+        final Tracer tracer = mock(Tracer.class);
+        final TracerPlugin tracerPlugin = mock(TracerPlugin.class);
+        when(tracerPlugin.createTracer(anyMap())).thenReturn(tracer);
+
+        final TracerProvider tracerProvider = new TracerProvider(
+                Collections.singletonMap("myTracer", tracerPlugin),
+                Collections.<String, TracerTag>emptyMap()
+        );
+
+        tracerProvider.tracingSystem = "myTracer";
+        tracerProvider.get();
+        assertThat(GlobalTracer.isRegistered(), is(true));
+    }
+}

--- a/monitor-core/pom.xml
+++ b/monitor-core/pom.xml
@@ -39,6 +39,10 @@
             <artifactId>spals-appbuilder-annotations</artifactId>
         </dependency>
         <dependency>
+            <groupId>net.spals.appbuilder</groupId>
+            <artifactId>spals-appbuilder-config</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.inferred</groupId>
             <artifactId>freebuilder</artifactId>
         </dependency>

--- a/monitor-core/pom.xml
+++ b/monitor-core/pom.xml
@@ -35,6 +35,10 @@
             <artifactId>opentracing-noop</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.opentracing</groupId>
+            <artifactId>opentracing-util</artifactId>
+        </dependency>
+        <dependency>
             <groupId>net.spals.appbuilder</groupId>
             <artifactId>spals-appbuilder-annotations</artifactId>
         </dependency>

--- a/monitor-core/pom.xml
+++ b/monitor-core/pom.xml
@@ -1,0 +1,47 @@
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+    <parent>
+        <groupId>net.spals.appbuilder</groupId>
+        <artifactId>spals-appbuilder-parent</artifactId>
+        <version>0.0.4-SNAPSHOT</version>
+    </parent>
+
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>net.spals.appbuilder</groupId>
+    <artifactId>spals-appbuilder-monitor-core</artifactId>
+    <version>0.0.4-SNAPSHOT</version>
+    <packaging>jar</packaging>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.netflix.governator</groupId>
+            <artifactId>governator-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.typesafe</groupId>
+            <artifactId>config</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.opentracing</groupId>
+            <artifactId>opentracing-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.opentracing</groupId>
+            <artifactId>opentracing-noop</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>net.spals.appbuilder</groupId>
+            <artifactId>spals-appbuilder-annotations</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.inferred</groupId>
+            <artifactId>freebuilder</artifactId>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/monitor-core/src/main/java/net/spals/appbuilder/monitor/core/TracerPlugin.java
+++ b/monitor-core/src/main/java/net/spals/appbuilder/monitor/core/TracerPlugin.java
@@ -2,6 +2,8 @@ package net.spals.appbuilder.monitor.core;
 
 import io.opentracing.Tracer;
 
+import java.util.Map;
+
 /**
  * A plugin definition for creating a
  * {@link Tracer} object specific to a
@@ -11,5 +13,5 @@ import io.opentracing.Tracer;
  */
 public interface TracerPlugin {
 
-    Tracer createTracer();
+    Tracer createTracer(final Map<String, TracerTag> tracerTagMap);
 }

--- a/monitor-core/src/main/java/net/spals/appbuilder/monitor/core/TracerPlugin.java
+++ b/monitor-core/src/main/java/net/spals/appbuilder/monitor/core/TracerPlugin.java
@@ -1,0 +1,15 @@
+package net.spals.appbuilder.monitor.core;
+
+import io.opentracing.Tracer;
+
+/**
+ * A plugin definition for creating a
+ * {@link Tracer} object specific to a
+ * particular opentracing implementation.
+ *
+ * @author tkral
+ */
+public interface TracerPlugin {
+
+    Tracer createTracer();
+}

--- a/monitor-core/src/main/java/net/spals/appbuilder/monitor/core/TracerProvider.java
+++ b/monitor-core/src/main/java/net/spals/appbuilder/monitor/core/TracerProvider.java
@@ -5,6 +5,7 @@ import com.google.inject.Provider;
 import com.netflix.governator.annotations.Configuration;
 import com.typesafe.config.ConfigException;
 import io.opentracing.Tracer;
+import io.opentracing.util.GlobalTracer;
 import net.spals.appbuilder.annotations.service.AutoBindProvider;
 
 import java.util.Map;
@@ -31,9 +32,14 @@ class TracerProvider implements Provider<Tracer> {
 
     @Override
     public Tracer get() {
-        return Optional.ofNullable(tracerPluginMap.get(tracingSystem))
+        // Lookup the tracer from the available plugins
+        final Tracer tracer = Optional.ofNullable(tracerPluginMap.get(tracingSystem))
             .map(tracerPlugin -> tracerPlugin.createTracer(tracerTagMap))
             .orElseThrow(() -> new ConfigException.BadValue("tracing.system",
                 "No Tracing plugin found for : " + tracingSystem));
+
+        // Register the tracer as the global tracer
+        GlobalTracer.register(tracer);
+        return tracer;
     }
 }

--- a/monitor-core/src/main/java/net/spals/appbuilder/monitor/core/TracerProvider.java
+++ b/monitor-core/src/main/java/net/spals/appbuilder/monitor/core/TracerProvider.java
@@ -1,0 +1,36 @@
+package net.spals.appbuilder.monitor.core;
+
+import com.google.inject.Inject;
+import com.google.inject.Provider;
+import com.netflix.governator.annotations.Configuration;
+import com.typesafe.config.ConfigException;
+import io.opentracing.Tracer;
+import net.spals.appbuilder.annotations.service.AutoBindProvider;
+
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * @author tkral
+ */
+@AutoBindProvider
+class TracerProvider implements Provider<Tracer> {
+
+    @Configuration("tracing.system")
+    private volatile String tracingSystem = "noop";
+
+    private final Map<String, TracerPlugin> tracerPluginMap;
+
+    @Inject
+    TracerProvider(final Map<String, TracerPlugin> tracerPluginMap) {
+        this.tracerPluginMap = tracerPluginMap;
+    }
+
+    @Override
+    public Tracer get() {
+        return Optional.ofNullable(tracerPluginMap.get(tracingSystem))
+            .map(tracerPlugin -> tracerPlugin.createTracer())
+            .orElseThrow(() -> new ConfigException.BadValue("tracing.system",
+                "No Tracing plugin found for : " + tracingSystem));
+    }
+}

--- a/monitor-core/src/main/java/net/spals/appbuilder/monitor/core/TracerProvider.java
+++ b/monitor-core/src/main/java/net/spals/appbuilder/monitor/core/TracerProvider.java
@@ -20,16 +20,19 @@ class TracerProvider implements Provider<Tracer> {
     private volatile String tracingSystem = "noop";
 
     private final Map<String, TracerPlugin> tracerPluginMap;
+    private final Map<String, TracerTag> tracerTagMap;
 
     @Inject
-    TracerProvider(final Map<String, TracerPlugin> tracerPluginMap) {
+    TracerProvider(final Map<String, TracerPlugin> tracerPluginMap,
+                   final Map<String, TracerTag> tracerTagMap) {
         this.tracerPluginMap = tracerPluginMap;
+        this.tracerTagMap = tracerTagMap;
     }
 
     @Override
     public Tracer get() {
         return Optional.ofNullable(tracerPluginMap.get(tracingSystem))
-            .map(tracerPlugin -> tracerPlugin.createTracer())
+            .map(tracerPlugin -> tracerPlugin.createTracer(tracerTagMap))
             .orElseThrow(() -> new ConfigException.BadValue("tracing.system",
                 "No Tracing plugin found for : " + tracingSystem));
     }

--- a/monitor-core/src/main/java/net/spals/appbuilder/monitor/core/TracerProvider.java
+++ b/monitor-core/src/main/java/net/spals/appbuilder/monitor/core/TracerProvider.java
@@ -1,5 +1,6 @@
 package net.spals.appbuilder.monitor.core;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.inject.Inject;
 import com.google.inject.Provider;
 import com.netflix.governator.annotations.Configuration;
@@ -18,7 +19,8 @@ import java.util.Optional;
 class TracerProvider implements Provider<Tracer> {
 
     @Configuration("tracing.system")
-    private volatile String tracingSystem = "noop";
+    @VisibleForTesting
+    volatile String tracingSystem = "noop";
 
     private final Map<String, TracerPlugin> tracerPluginMap;
     private final Map<String, TracerTag> tracerTagMap;

--- a/monitor-core/src/main/java/net/spals/appbuilder/monitor/core/TracerTag.java
+++ b/monitor-core/src/main/java/net/spals/appbuilder/monitor/core/TracerTag.java
@@ -1,9 +1,11 @@
 package net.spals.appbuilder.monitor.core;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import io.opentracing.Tracer;
-import org.inferred.freebuilder.FreeBuilder;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import io.opentracing.Tracer;
+import net.spals.appbuilder.config.TaggedConfig;
+import org.inferred.freebuilder.FreeBuilder;
 
 /**
  * A bean which represents a tag
@@ -16,13 +18,26 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
  */
 @FreeBuilder
 @JsonDeserialize(builder = TracerTag.Builder.class)
-public interface TracerTag {
+public interface TracerTag extends TaggedConfig {
 
-    @JsonProperty("key")
-    String getKey();
+    String TAG_VALUE_KEY = "tagValue";
 
-    @JsonProperty("value")
+    @Override
+    @JsonIgnore
+    default boolean isActive() {
+        return true;
+    }
+
+    @JsonIgnore
+    default String getKey() {
+        return getTag();
+    }
+
+    @JsonProperty(TAG_VALUE_KEY)
     Object getValue();
+
+    @Override
+    String getTag();
 
     class Builder extends TracerTag_Builder {  }
 }

--- a/monitor-core/src/main/java/net/spals/appbuilder/monitor/core/TracerTag.java
+++ b/monitor-core/src/main/java/net/spals/appbuilder/monitor/core/TracerTag.java
@@ -1,0 +1,28 @@
+package net.spals.appbuilder.monitor.core;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.opentracing.Tracer;
+import org.inferred.freebuilder.FreeBuilder;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+
+/**
+ * A bean which represents a tag
+ * to be attched to a {@link Tracer} instance.
+ *
+ * We do this so that we can deserialize
+ * multiple tags out of the service configuration.
+ *
+ * @author tkral
+ */
+@FreeBuilder
+@JsonDeserialize(builder = TracerTag.Builder.class)
+public interface TracerTag {
+
+    @JsonProperty("key")
+    String getKey();
+
+    @JsonProperty("value")
+    Object getValue();
+
+    class Builder extends TracerTag_Builder {  }
+}

--- a/monitor-core/src/main/java/net/spals/appbuilder/monitor/core/noop/NoopTracerPlugin.java
+++ b/monitor-core/src/main/java/net/spals/appbuilder/monitor/core/noop/NoopTracerPlugin.java
@@ -5,6 +5,9 @@ import io.opentracing.NoopTracerFactory;
 import io.opentracing.Tracer;
 import net.spals.appbuilder.annotations.service.AutoBindInMap;
 import net.spals.appbuilder.monitor.core.TracerPlugin;
+import net.spals.appbuilder.monitor.core.TracerTag;
+
+import java.util.Map;
 
 /**
  * A {@link TracerPlugin} for the
@@ -16,7 +19,7 @@ import net.spals.appbuilder.monitor.core.TracerPlugin;
 class NoopTracerPlugin implements TracerPlugin {
 
     @Override
-    public Tracer createTracer() {
+    public Tracer createTracer(final Map<String, TracerTag> tracerTagMap) {
         return NoopTracerFactory.create();
     }
 }

--- a/monitor-core/src/main/java/net/spals/appbuilder/monitor/core/noop/NoopTracerPlugin.java
+++ b/monitor-core/src/main/java/net/spals/appbuilder/monitor/core/noop/NoopTracerPlugin.java
@@ -1,0 +1,22 @@
+package net.spals.appbuilder.monitor.core.noop;
+
+import io.opentracing.NoopTracer;
+import io.opentracing.NoopTracerFactory;
+import io.opentracing.Tracer;
+import net.spals.appbuilder.annotations.service.AutoBindInMap;
+import net.spals.appbuilder.monitor.core.TracerPlugin;
+
+/**
+ * A {@link TracerPlugin} for the
+ * {@link NoopTracer}.
+ *
+ * @author tkral
+ */
+@AutoBindInMap(baseClass = TracerPlugin.class, key = "noop")
+class NoopTracerPlugin implements TracerPlugin {
+
+    @Override
+    public Tracer createTracer() {
+        return NoopTracerFactory.create();
+    }
+}

--- a/monitor-lightstep/pom.xml
+++ b/monitor-lightstep/pom.xml
@@ -1,0 +1,39 @@
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+    <parent>
+        <groupId>net.spals.appbuilder</groupId>
+        <artifactId>spals-appbuilder-parent</artifactId>
+        <version>0.0.4-SNAPSHOT</version>
+    </parent>
+
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>net.spals.appbuilder.plugins</groupId>
+    <artifactId>spals-appbuilder-monitor-lightstep</artifactId>
+    <version>0.0.4-SNAPSHOT</version>
+    <packaging>jar</packaging>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.lightstep.tracer</groupId>
+            <artifactId>lightstep-tracer-jre</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>javax.validation</groupId>
+            <artifactId>validation-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>net.spals.appbuilder</groupId>
+            <artifactId>spals-appbuilder-monitor-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.scala-lang</groupId>
+            <artifactId>scala-library</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.scala-lang.modules</groupId>
+            <artifactId>scala-java8-compat_${scala.version}</artifactId>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/monitor-lightstep/src/main/scala/net/spals/appbuilder/monitor/lightstep/LightstepTracerPlugin.scala
+++ b/monitor-lightstep/src/main/scala/net/spals/appbuilder/monitor/lightstep/LightstepTracerPlugin.scala
@@ -1,6 +1,5 @@
 package net.spals.appbuilder.monitor.lightstep
 
-import java.util.Collections
 import javax.validation.constraints.{NotNull, Pattern}
 
 import com.google.inject.Inject
@@ -15,8 +14,8 @@ import net.spals.appbuilder.monitor.core.{TracerPlugin, TracerTag}
 import scala.collection.JavaConverters._
 
 /**
-  * A [[TracerPlugin]] for a Lightstep
-  * Java [[Tracer]] instance.
+  * Implementation of [[TracerPlugin]] which
+  * uses Lightstep [[JRETracer]].
   *
   * @author tkral
   */
@@ -39,10 +38,7 @@ private[lightstep] class LightstepTracerPlugin @Inject() (
   @Configuration("tracing.lightstep.collectorProtocol")
   private[lightstep] var collectorProtocol: String = "http"
 
-  @Configuration("tracing.lightstep.tracerTags")
-  private[lightstep] var tracerTags: java.util.List[TracerTag] = Collections.emptyList[TracerTag]()
-
-  override def createTracer(): Tracer = {
+  override def createTracer(tracerTagMap: java.util.Map[String, TracerTag]): Tracer = {
     val optionsBuilder = new Options.OptionsBuilder()
       .withAccessToken(accessToken)
       .withComponentName(applicationName)
@@ -50,7 +46,8 @@ private[lightstep] class LightstepTracerPlugin @Inject() (
 
     Option(collectorHost).foreach(optionsBuilder.withCollectorHost(_))
     Option(collectorPort).filter(_ != 0).foreach(optionsBuilder.withCollectorPort(_))
-    tracerTags.asScala.foreach(tracerTag => optionsBuilder.withTag(tracerTag.getKey, tracerTag.getValue))
+    tracerTagMap.values().asScala
+      .foreach(tracerTag => optionsBuilder.withTag(tracerTag.getKey, tracerTag.getValue))
 
     new JRETracer(optionsBuilder.build())
   }

--- a/monitor-lightstep/src/main/scala/net/spals/appbuilder/monitor/lightstep/LightstepTracerPlugin.scala
+++ b/monitor-lightstep/src/main/scala/net/spals/appbuilder/monitor/lightstep/LightstepTracerPlugin.scala
@@ -1,0 +1,57 @@
+package net.spals.appbuilder.monitor.lightstep
+
+import java.util.Collections
+import javax.validation.constraints.{NotNull, Pattern}
+
+import com.google.inject.Inject
+import com.lightstep.tracer.jre.JRETracer
+import com.lightstep.tracer.shared.Options
+import com.netflix.governator.annotations.Configuration
+import io.opentracing.Tracer
+import net.spals.appbuilder.annotations.config.ApplicationName
+import net.spals.appbuilder.annotations.service.AutoBindInMap
+import net.spals.appbuilder.monitor.core.{TracerPlugin, TracerTag}
+
+import scala.collection.JavaConverters._
+
+/**
+  * A [[TracerPlugin]] for a Lightstep
+  * Java [[Tracer]] instance.
+  *
+  * @author tkral
+  */
+@AutoBindInMap(baseClass = classOf[TracerPlugin], key = "lightstep")
+private[lightstep] class LightstepTracerPlugin @Inject() (
+  @ApplicationName applicationName: String
+) extends TracerPlugin {
+
+  @NotNull
+  @Configuration("tracing.lightstep.accessToken")
+  private[lightstep] var accessToken: String = null
+
+  @Configuration("tracing.lightstep.collectorHost")
+  private[lightstep] var collectorHost: String = null
+
+  @Configuration("tracing.lightstep.collectorPort")
+  private[lightstep] var collectorPort: Int = 0
+
+  @Pattern(regexp = "(http|https)")
+  @Configuration("tracing.lightstep.collectorProtocol")
+  private[lightstep] var collectorProtocol: String = "http"
+
+  @Configuration("tracing.lightstep.tracerTags")
+  private[lightstep] var tracerTags: java.util.List[TracerTag] = Collections.emptyList[TracerTag]()
+
+  override def createTracer(): Tracer = {
+    val optionsBuilder = new Options.OptionsBuilder()
+      .withAccessToken(accessToken)
+      .withComponentName(applicationName)
+      .withCollectorProtocol(collectorProtocol)
+
+    Option(collectorHost).foreach(optionsBuilder.withCollectorHost(_))
+    Option(collectorPort).filter(_ != 0).foreach(optionsBuilder.withCollectorPort(_))
+    tracerTags.asScala.foreach(tracerTag => optionsBuilder.withTag(tracerTag.getKey, tracerTag.getValue))
+
+    new JRETracer(optionsBuilder.build())
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -115,6 +115,7 @@
         <module>model-protobuf</module>
         <module>model-protobuf-test</module>
         <module>monitor-core</module>
+        <module>monitor-core-test</module>
         <module>monitor-lightstep</module>
     </modules>
 

--- a/pom.xml
+++ b/pom.xml
@@ -71,6 +71,7 @@
         <logback.version>1.2.1</logback.version>
         <mapdb.version>3.0.3</mapdb.version>
         <opentracing.aws.version>0.0.2</opentracing.aws.version>
+        <opentracing.concurrent.version>0.0.2</opentracing.concurrent.version>
         <opentracing.version>0.30.0</opentracing.version>
         <protobuf.version>3.3.0</protobuf.version>
         <reflections.version>0.9.10</reflections.version>
@@ -302,6 +303,11 @@
                         <artifactId>aws-java-sdk</artifactId>
                     </exclusion>
                 </exclusions>
+            </dependency>
+            <dependency>
+                <groupId>io.opentracing.contrib</groupId>
+                <artifactId>opentracing-concurrent</artifactId>
+                <version>${opentracing.concurrent.version}</version>
             </dependency>
             <dependency>
                 <groupId>javax.servlet</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -67,8 +67,10 @@
         <kinesis-client.version>1.7.4</kinesis-client.version>
         <kinesis-producer.version>0.12.3</kinesis-producer.version>
         <kryo-serializers.version>0.41</kryo-serializers.version>
+        <lightstep.tracer.version>0.12.15</lightstep.tracer.version>
         <logback.version>1.2.1</logback.version>
         <mapdb.version>3.0.3</mapdb.version>
+        <opentracing.version>0.30.0</opentracing.version>
         <protobuf.version>3.3.0</protobuf.version>
         <reflections.version>0.9.10</reflections.version>
         <typesafe.config.version>1.3.1</typesafe.config.version>
@@ -109,6 +111,8 @@
         <module>model-core-test</module>
         <module>model-protobuf</module>
         <module>model-protobuf-test</module>
+        <module>monitor-core</module>
+        <module>monitor-lightstep</module>
     </modules>
 
     <dependencyManagement>
@@ -163,6 +167,11 @@
                 <groupId>com.github.jlmauduy</groupId>
                 <artifactId>ascii-graphs_${scala.version}</artifactId>
                 <version>${ascii-graphs.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.lightstep.tracer</groupId>
+                <artifactId>lightstep-tracer-jre</artifactId>
+                <version>${lightstep.tracer.version}</version>
             </dependency>
             <dependency>
                 <groupId>com.netflix.governator</groupId>
@@ -266,6 +275,22 @@
                 <scope>test</scope>
             </dependency>
             <dependency>
+                <groupId>io.opentracing</groupId>
+                <artifactId>opentracing-api</artifactId>
+                <version>${opentracing.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.opentracing</groupId>
+                <artifactId>opentracing-noop</artifactId>
+                <version>${opentracing.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.opentracing</groupId>
+                <artifactId>opentracing-mock</artifactId>
+                <version>${opentracing.version}</version>
+                <scope>tests</scope>
+            </dependency>
+            <dependency>
                 <groupId>javax.servlet</groupId>
                 <artifactId>javax.servlet-api</artifactId>
                 <version>${javax.servlet-api.version}</version>
@@ -332,6 +357,11 @@
                 <version>${project.version}</version>
             </dependency>
             <dependency>
+                <groupId>net.spals.appbuilder</groupId>
+                <artifactId>spals-appbuilder-monitor-core</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
                 <groupId>net.spals.appbuilder.plugins</groupId>
                 <artifactId>spals-appbuilder-app-dropwizard</artifactId>
                 <version>${project.version}</version>
@@ -369,6 +399,11 @@
             <dependency>
                 <groupId>net.spals.appbuilder.plugins</groupId>
                 <artifactId>spals-appbuilder-model-protobuf</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>net.spals.appbuilder.plugins</groupId>
+                <artifactId>spals-appbuilder-monitor-lightstep</artifactId>
                 <version>${project.version}</version>
             </dependency>
             <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -72,6 +72,7 @@
         <mapdb.version>3.0.3</mapdb.version>
         <opentracing.aws.version>0.0.2</opentracing.aws.version>
         <opentracing.concurrent.version>0.0.2</opentracing.concurrent.version>
+        <opentracing.jaxrs2.version>0.0.9</opentracing.jaxrs2.version>
         <opentracing.version>0.30.0</opentracing.version>
         <protobuf.version>3.3.0</protobuf.version>
         <reflections.version>0.9.10</reflections.version>
@@ -313,6 +314,11 @@
                 <groupId>io.opentracing.contrib</groupId>
                 <artifactId>opentracing-concurrent</artifactId>
                 <version>${opentracing.concurrent.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.opentracing.contrib</groupId>
+                <artifactId>opentracing-jaxrs2</artifactId>
+                <version>${opentracing.jaxrs2.version}</version>
             </dependency>
             <dependency>
                 <groupId>javax.servlet</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -70,6 +70,7 @@
         <lightstep.tracer.version>0.12.15</lightstep.tracer.version>
         <logback.version>1.2.1</logback.version>
         <mapdb.version>3.0.3</mapdb.version>
+        <opentracing.aws.version>0.0.2</opentracing.aws.version>
         <opentracing.version>0.30.0</opentracing.version>
         <protobuf.version>3.3.0</protobuf.version>
         <reflections.version>0.9.10</reflections.version>
@@ -289,6 +290,18 @@
                 <artifactId>opentracing-mock</artifactId>
                 <version>${opentracing.version}</version>
                 <scope>tests</scope>
+            </dependency>
+            <dependency>
+                <groupId>io.opentracing.contrib</groupId>
+                <artifactId>opentracing-aws-sdk</artifactId>
+                <version>${opentracing.aws.version}</version>
+                <!-- Exclude so that we can bring in our own version of the SDK -->
+                <exclusions>
+                    <exclusion>
+                        <groupId>com.amazonaws</groupId>
+                        <artifactId>aws-java-sdk</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
                 <groupId>javax.servlet</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -293,6 +293,11 @@
                 <scope>tests</scope>
             </dependency>
             <dependency>
+                <groupId>io.opentracing</groupId>
+                <artifactId>opentracing-util</artifactId>
+                <version>${opentracing.version}</version>
+            </dependency>
+            <dependency>
                 <groupId>io.opentracing.contrib</groupId>
                 <artifactId>opentracing-aws-sdk</artifactId>
                 <version>${opentracing.aws.version}</version>


### PR DESCRIPTION
@thespags 

Adding a new module in AppBuilder for request tracing. It's based on the [OpenTracing library](https://github.com/opentracing/opentracing-java) (OpenTracing specification is [here](https://github.com/opentracing/specification) if you want to read it).

The idea here is to allow requests coming into an application to be traced and the timing metrics written out to an external system for reporting. OpenTracing is a similar concept to slf4j. It provides an interface for tracing requests and then there are [multiple available implementations by different vendors](http://opentracing.io/documentation/pages/supported-tracers.html) as well as [several integrations with popular frameworks](https://github.com/opentracing-contrib).

OpenTracing is perfectly suited for AppBuilder because it's designed in the exact way that AppBuilder needs:

1. Everything sits behind a `Tracer` interface so the implementation details for any particular vendor are completely hidden.
2. It includes a noop tracer which AppBuilder uses as the default if nothing is provided.
3. It includes a mock tracer for tests.
4. It includes integrations with other frameworks that AppBuilder already uses.

This PR includes several things:

1. Three new modules:
  - `monitor-core`: The core elements for monitoring. This defines a [Guice Provider](https://google.github.io/guice/api-docs/latest/javadoc/index.html?com/google/inject/Provider.html) for an OpenTracing [Tracer](http://javadoc.io/doc/io.opentracing/opentracing-api/0.30.0) instance. It also has a plugin to create a [NoopTracer](http://javadoc.io/doc/io.opentracing/opentracing-noop/0.30.0) by default.
- `monitor-core-test`: Test module for `monitor-core`
- `monitor-lightstep`: Provides a vendor-specific `Tracer` instance for [Lightstep](http://lightstep.com/) (using the [Lightstep Java integration](https://github.com/lightstep/lightstep-tracer-java))
2. Integrates the `Tracer` with `JaxRsWebApp` and `DropwizardWebApp` using the [OpenTracing JaxRs integration](https://github.com/opentracing-contrib/java-jaxrs). Also has tests for this integration.
3. Integrates the `Tracer`with `DynamoDBMapStorePlugin` and `S3FileStorePlugin` using the [OpenTracing AWS integration](https://github.com/opentracing-contrib/java-aws-sdk). Also has tests for this integration.
4. Integrates the `Tracer` with the `executor-core` module usingthe [OpenTracing Java Concurrent integration](https://github.com/opentracing-contrib/java-concurrent). No tests for this, but coming soon.
5. Introduces the concept of default micro-services. Default micro-services are those which are used throughout AppBuilder. For example, the `Tracer` and `ExecutorServiceFactory` are used all over the place. So instead of an application having to explicitly use them, AppBuilder will now include them automatically.
