### PR TITLE
Tracing for Finatra and Cassandra

### DIFF
--- a/app-core/src/main/java/net/spals/appbuilder/app/core/jaxrs/JaxRsMonitorModule.java
+++ b/app-core/src/main/java/net/spals/appbuilder/app/core/jaxrs/JaxRsMonitorModule.java
@@ -1,12 +1,15 @@
 package net.spals.appbuilder.app.core.jaxrs;
 
+import com.google.common.collect.ImmutableList;
 import com.google.inject.AbstractModule;
 import com.google.inject.matcher.Matcher;
 import com.google.inject.spi.ProvisionListener;
 import com.google.inject.spi.ProvisionListener.ProvisionInvocation;
 import io.opentracing.Tracer;
+import io.opentracing.contrib.jaxrs2.server.ServerSpanDecorator;
 import io.opentracing.contrib.jaxrs2.server.ServerTracingDynamicFeature;
 import net.spals.appbuilder.app.core.matcher.BindingMatchers;
+import net.spals.appbuilder.app.core.monitor.ParamSpanDecorator;
 import org.inferred.freebuilder.FreeBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -44,7 +47,11 @@ public abstract class JaxRsMonitorModule extends AbstractModule
     void registerTracer(final Tracer tracer) {
         LOGGER.info("Enabling JaxRs server request tracing with OpenTracing");
         final ServerTracingDynamicFeature serverTracing =
-                new ServerTracingDynamicFeature.Builder(tracer).build();
+                new ServerTracingDynamicFeature.Builder(tracer)
+                        .withDecorators(ImmutableList.of(ServerSpanDecorator.STANDARD_TAGS,
+                                ServerSpanDecorator.HTTP_WILDCARD_PATH_OPERATION_NAME,
+                                new ParamSpanDecorator()))
+                        .build();
         getConfigurable().register(serverTracing);
     }
 }

--- a/app-core/src/main/java/net/spals/appbuilder/app/core/monitor/ParamSpanDecorator.java
+++ b/app-core/src/main/java/net/spals/appbuilder/app/core/monitor/ParamSpanDecorator.java
@@ -1,0 +1,33 @@
+package net.spals.appbuilder.app.core.monitor;
+
+import io.opentracing.BaseSpan;
+import io.opentracing.contrib.jaxrs2.server.ServerSpanDecorator;
+
+import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.container.ContainerResponseContext;
+import javax.ws.rs.core.MultivaluedMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Custom {@link ServerSpanDecorator} to add path parameter
+ * values as tags on the {@link io.opentracing.Span}.
+ *
+ * @author tkral
+ */
+public class ParamSpanDecorator implements ServerSpanDecorator {
+
+    @Override
+    public void decorateRequest(final ContainerRequestContext requestContext,
+                                final BaseSpan<?> span) {
+        final MultivaluedMap<String, String> pathParameters = requestContext.getUriInfo().getPathParameters();
+        for (Map.Entry<String, List<String>> entry: pathParameters.entrySet()) {
+            span.setTag(String.format("param.%s", entry.getKey()),
+                    String.valueOf(pathParameters.getFirst(entry.getKey())));
+        }
+    }
+
+    @Override
+    public void decorateResponse(final ContainerResponseContext responseContext,
+                                 final BaseSpan<?> span) {  }
+}

--- a/app-dropwizard-test/src/test/java/net/spals/appbuilder/app/dropwizard/TracingDropwizardWebAppFTest.java
+++ b/app-dropwizard-test/src/test/java/net/spals/appbuilder/app/dropwizard/TracingDropwizardWebAppFTest.java
@@ -72,4 +72,23 @@ public class TracingDropwizardWebAppFTest {
         assertThat(mockSpan.tags(), hasEntry("http.url", target));
         assertThat(mockSpan.tags(), hasEntry("span.kind", "server"));
     }
+
+    @Test
+    public void testServerRequestTracingWithParams() {
+        final String target = "http://localhost:" + testServerWrapper.getLocalPort() + "/tracing/noAnnotation/123";
+        final WebTarget webTarget = webClient.target(target);
+        webTarget.request().get();
+
+        final List<MockSpan> mockSpans = mockTracer.finishedSpans();
+        assertThat("No finished spans found.", mockSpans, hasSize(1));
+
+        final MockSpan mockSpan = mockSpans.get(0);
+        assertThat(mockSpan.generatedErrors(), empty());
+        assertThat(mockSpan.operationName(), is("tracing/noAnnotation/{id}"));
+        assertThat(mockSpan.tags(), hasEntry("http.method", "GET"));
+        assertThat(mockSpan.tags(), hasEntry("http.status_code", 200));
+        assertThat(mockSpan.tags(), hasEntry("http.url", target));
+        assertThat(mockSpan.tags(), hasEntry("param.id", "123"));
+        assertThat(mockSpan.tags(), hasEntry("span.kind", "server"));
+    }
 }

--- a/app-dropwizard-test/src/test/java/net/spals/appbuilder/app/dropwizard/tracing/TracingDropwizardResource.java
+++ b/app-dropwizard-test/src/test/java/net/spals/appbuilder/app/dropwizard/tracing/TracingDropwizardResource.java
@@ -5,6 +5,7 @@ import net.spals.appbuilder.annotations.service.AutoBindSingleton;
 
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
 import javax.ws.rs.core.Response;
 
 /**
@@ -21,6 +22,12 @@ public class TracingDropwizardResource {
     @GET
     @Path("noAnnotation")
     public Response getTracingNoAnnotation() {
+        return Response.ok().build();
+    }
+
+    @GET
+    @Path("noAnnotation/{id}")
+    public Response getTrachingNoAnnotation(@PathParam("id") final String id) {
         return Response.ok().build();
     }
 

--- a/app-finatra-test/pom.xml
+++ b/app-finatra-test/pom.xml
@@ -52,6 +52,10 @@
             <artifactId>catch-throwable</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.opentracing</groupId>
+            <artifactId>opentracing-mock</artifactId>
+        </dependency>
+        <dependency>
             <groupId>net.spals.appbuilder</groupId>
             <artifactId>spals-appbuilder-executor-core</artifactId>
         </dependency>

--- a/app-finatra-test/src/test/scala/net/spals/appbuilder/app/finatra/TracingFinatraWebAppFTest.scala
+++ b/app-finatra-test/src/test/scala/net/spals/appbuilder/app/finatra/TracingFinatraWebAppFTest.scala
@@ -50,7 +50,21 @@ class TracingFinatraWebAppFTest {
     assertThat(mockSpan.operationName(), is("/tracing"))
     assertThat(mockSpan.tags(), hasEntry[String, AnyRef]("http.method", "GET"))
     assertThat(mockSpan.tags(), hasEntry[String, AnyRef]("http.status_code", Int.box(200)))
-//    assertThat(mockSpan.tags(), hasEntry[String, AnyRef]("http.url", ))
+    assertThat(mockSpan.tags(), hasEntry[String, AnyRef]("span.kind", "server"))
+  }
+
+  @Test def testServerRequestTracingWithParams() {
+    testServerWrapper.httpGet("/tracing/123")
+
+    val mockSpans = mockTracer.finishedSpans()
+    assertThat("No finished spans found.", mockSpans, hasSize[MockSpan](1))
+
+    val mockSpan = mockSpans.get(0)
+    assertThat(mockSpan.generatedErrors, empty[RuntimeException]())
+    assertThat(mockSpan.operationName(), is("/tracing/:id"))
+    assertThat(mockSpan.tags(), hasEntry[String, AnyRef]("http.method", "GET"))
+    assertThat(mockSpan.tags(), hasEntry[String, AnyRef]("http.status_code", Int.box(200)))
+    assertThat(mockSpan.tags(), hasEntry[String, AnyRef]("param.id", "123"))
     assertThat(mockSpan.tags(), hasEntry[String, AnyRef]("span.kind", "server"))
   }
 }

--- a/app-finatra-test/src/test/scala/net/spals/appbuilder/app/finatra/TracingFinatraWebAppFTest.scala
+++ b/app-finatra-test/src/test/scala/net/spals/appbuilder/app/finatra/TracingFinatraWebAppFTest.scala
@@ -1,0 +1,56 @@
+package net.spals.appbuilder.app.finatra
+
+import com.google.inject.Stage
+import com.twitter.finatra.http.EmbeddedHttpServer
+import io.opentracing.mock.MockSpan
+import net.spals.appbuilder.app.finatra.tracing.TracingFinatraWebApp
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.empty
+import org.hamcrest.Matchers.hasEntry
+import org.hamcrest.Matchers.hasSize
+import org.hamcrest.Matchers.is
+import org.testng.annotations.AfterClass
+import org.testng.annotations.BeforeClass
+import org.testng.annotations.BeforeMethod
+import org.testng.annotations.Test
+
+/**
+  * Functional tests for request tracing in a [[FinatraWebApp]]
+  * (see [[TracingFinatraWebApp]]).
+  */
+class TracingFinatraWebAppFTest {
+
+  private val tracingApp = new TracingFinatraWebApp()
+  private val testServerWrapper = new EmbeddedHttpServer(
+    twitterServer = tracingApp,
+    stage = Stage.PRODUCTION
+  )
+  private val mockTracer = tracingApp.mockTracer
+
+  @BeforeClass def classSetup() {
+    testServerWrapper.start()
+  }
+
+  @BeforeMethod def resetTracer() {
+    mockTracer.reset()
+  }
+
+  @AfterClass def classTearDown() {
+    testServerWrapper.close()
+  }
+
+  @Test def testServerRequestTracing() {
+    testServerWrapper.httpGet("/tracing")
+
+    val mockSpans = mockTracer.finishedSpans()
+    assertThat("No finished spans found.", mockSpans, hasSize[MockSpan](1))
+
+    val mockSpan = mockSpans.get(0)
+    assertThat(mockSpan.generatedErrors, empty[RuntimeException]())
+    assertThat(mockSpan.operationName(), is("/tracing"))
+    assertThat(mockSpan.tags(), hasEntry[String, AnyRef]("http.method", "GET"))
+    assertThat(mockSpan.tags(), hasEntry[String, AnyRef]("http.status_code", Int.box(200)))
+//    assertThat(mockSpan.tags(), hasEntry[String, AnyRef]("http.url", ))
+    assertThat(mockSpan.tags(), hasEntry[String, AnyRef]("span.kind", "server"))
+  }
+}

--- a/app-finatra-test/src/test/scala/net/spals/appbuilder/app/finatra/tracing/TracingFinatraController.scala
+++ b/app-finatra-test/src/test/scala/net/spals/appbuilder/app/finatra/tracing/TracingFinatraController.scala
@@ -15,4 +15,8 @@ private[tracing] class TracingFinatraController extends Controller {
   get("/tracing") { request: Request =>
     response.ok
   }
+
+  get("/tracing/:id") { request: Request =>
+    response.ok
+  }
 }

--- a/app-finatra-test/src/test/scala/net/spals/appbuilder/app/finatra/tracing/TracingFinatraController.scala
+++ b/app-finatra-test/src/test/scala/net/spals/appbuilder/app/finatra/tracing/TracingFinatraController.scala
@@ -1,0 +1,18 @@
+package net.spals.appbuilder.app.finatra.tracing
+
+import com.twitter.finagle.http.Request
+import com.twitter.finatra.http.Controller
+import net.spals.appbuilder.annotations.service.AutoBindSingleton
+
+/**
+  * A Finatra [[Controller]] used in request tracing tests.
+  *
+  * @author tkral
+  */
+@AutoBindSingleton
+private[tracing] class TracingFinatraController extends Controller {
+
+  get("/tracing") { request: Request =>
+    response.ok
+  }
+}

--- a/app-finatra-test/src/test/scala/net/spals/appbuilder/app/finatra/tracing/TracingFinatraWebApp.scala
+++ b/app-finatra-test/src/test/scala/net/spals/appbuilder/app/finatra/tracing/TracingFinatraWebApp.scala
@@ -1,0 +1,31 @@
+package net.spals.appbuilder.app.finatra.tracing
+
+import com.google.inject.Binder
+import com.google.inject.Module
+import io.opentracing.Tracer
+import io.opentracing.mock.MockTracer
+import net.spals.appbuilder.app.finatra.FinatraWebApp
+import net.spals.appbuilder.config.service.ServiceScan
+
+/**
+  * A [[FinatraWebApp]] which uses all various service plugins.
+  *
+  * @author tkral
+  */
+object TracingFinatraWebAppMain extends TracingFinatraWebApp
+
+private[finatra] class TracingFinatraWebApp extends FinatraWebApp {
+
+  val mockTracer = new MockTracer()
+
+  setServiceScan(new ServiceScan.Builder()
+    .addServicePackages("net.spals.appbuilder.app.finatra.tracing")
+    .build())
+  addModule(new Module {
+    override def configure(binder: Binder): Unit =
+      binder.bind(classOf[Tracer]).toInstance(mockTracer)
+  })
+  enableBindingOverrides()
+  build()
+
+}

--- a/app-finatra/pom.xml
+++ b/app-finatra/pom.xml
@@ -35,6 +35,10 @@
             <artifactId>inject-request-scope_${scala.version}</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.opentracing.contrib</groupId>
+            <artifactId>opentracing-jaxrs2</artifactId>
+        </dependency>
+        <dependency>
             <groupId>net.spals.appbuilder</groupId>
             <artifactId>spals-appbuilder-app-core</artifactId>
         </dependency>

--- a/app-finatra/src/main/scala/net/spals/appbuilder/app/finatra/FinatraWebApp.scala
+++ b/app-finatra/src/main/scala/net/spals/appbuilder/app/finatra/FinatraWebApp.scala
@@ -14,6 +14,7 @@ import com.twitter.util.StorageUnit
 import com.typesafe.config._
 import net.spals.appbuilder.app.core.modules.{AutoBindConfigModule, AutoBindServiceGraphModule, AutoBindServicesModule}
 import net.spals.appbuilder.app.finatra.bootstrap.FinatraBootstrapModule
+import net.spals.appbuilder.app.finatra.modules.FinatraMonitorModule
 import net.spals.appbuilder.app.finatra.modules.{AutoBindConfigFlagsModule, FinatraWebServerModule}
 import net.spals.appbuilder.app.{core => spals}
 import net.spals.appbuilder.config.service.ServiceScan
@@ -65,6 +66,8 @@ trait FinatraWebApp extends HttpServer
   // ========== Twitter HttpServer ==========
 
   override protected def configureHttp(router: HttpRouter): Unit = {
+    // TODO (tkral): Does this work with post-routing filters?
+    monitorModule.runMonitoringAutoBind(router)
     webServerModule.runWebServerAutoBind(router)
   }
 
@@ -103,6 +106,7 @@ trait FinatraWebApp extends HttpServer
 
   private var bootstrapModule = new FinatraBootstrapModule()
   private val configModuleBuilder = new AutoBindConfigModule.Builder(getName)
+  private val monitorModule = new FinatraMonitorModule
   private val serviceGraphModuleBuilder = new AutoBindServiceGraphModule.Builder(serviceGraph)
   private var webServerModule = FinatraWebServerModule(serviceGraph)
 
@@ -171,6 +175,7 @@ trait FinatraWebApp extends HttpServer
 
     addFrameworkModules(
       bootstrapModule,
+      monitorModule,
       webServerModule
     )
     // Bind alternate config values under @Flag annotations

--- a/app-finatra/src/main/scala/net/spals/appbuilder/app/finatra/modules/FinatraMonitorModule.scala
+++ b/app-finatra/src/main/scala/net/spals/appbuilder/app/finatra/modules/FinatraMonitorModule.scala
@@ -1,0 +1,39 @@
+package net.spals.appbuilder.app.finatra.modules
+
+import java.util.concurrent.atomic.AtomicReference
+
+import com.google.inject.spi.ProvisionListener
+import com.twitter.finatra.http.routing.HttpRouter
+import com.twitter.inject.TwitterModule
+import io.opentracing.Tracer
+import net.spals.appbuilder.app.core.matcher.BindingMatchers
+import net.spals.appbuilder.app.finatra.monitor.FinatraTracingFilter
+
+/**
+  * Created by timkral on 9/18/17.
+  */
+private[finatra] class FinatraMonitorModule
+  extends TwitterModule
+  with ProvisionListener {
+
+  private val tracerRef = new AtomicReference[Tracer]()
+
+  override def configure(): Unit = {
+    val bindingMatcher = BindingMatchers.withKeyTypeSubclassOf(classOf[Tracer])
+    bindListener(bindingMatcher, this)
+  }
+
+  override def onProvision[T](provision: ProvisionListener.ProvisionInvocation[T]): Unit = {
+    val monitorComponent = provision.provision()
+
+    monitorComponent match {
+      case tracer: Tracer => tracerRef.set(tracer)
+      case _ => warn(s"Encountered unknown monitoring component: ${monitorComponent.getClass}")
+    }
+  }
+
+  private[finatra] def runMonitoringAutoBind(router: HttpRouter): Unit = {
+    Option(tracerRef.get()).map(new FinatraTracingFilter(_))
+      .foreach(router.filter(_, beforeRouting = true))
+  }
+}

--- a/app-finatra/src/main/scala/net/spals/appbuilder/app/finatra/modules/FinatraMonitorModule.scala
+++ b/app-finatra/src/main/scala/net/spals/appbuilder/app/finatra/modules/FinatraMonitorModule.scala
@@ -10,7 +10,7 @@ import net.spals.appbuilder.app.core.matcher.BindingMatchers
 import net.spals.appbuilder.app.finatra.monitor.FinatraTracingFilter
 
 /**
-  * Created by timkral on 9/18/17.
+  * @author tkral
   */
 private[finatra] class FinatraMonitorModule
   extends TwitterModule
@@ -32,8 +32,8 @@ private[finatra] class FinatraMonitorModule
     }
   }
 
-  private[finatra] def runMonitoringAutoBind(router: HttpRouter): Unit = {
+  private[finatra] def runMonitoringAutoBind(router: HttpRouter) = {
     Option(tracerRef.get()).map(new FinatraTracingFilter(_))
-      .foreach(router.filter(_, beforeRouting = true))
+      .foreach(router.filter(_, beforeRouting = false))
   }
 }

--- a/app-finatra/src/main/scala/net/spals/appbuilder/app/finatra/modules/FinatraWebServerModule.scala
+++ b/app-finatra/src/main/scala/net/spals/appbuilder/app/finatra/modules/FinatraWebServerModule.scala
@@ -4,11 +4,9 @@ import com.google.inject.TypeLiteral
 import com.google.inject.spi.{InjectionListener, TypeEncounter, TypeListener}
 import com.twitter.finagle.{Filter, http => finaglehttp}
 import com.twitter.finatra.http.Controller
-import com.twitter.finatra.http.exceptions.{ExceptionMapper, ExceptionMapperCollection}
-import com.twitter.finatra.http.filters.CommonFilters
+import com.twitter.finatra.http.exceptions.ExceptionMapper
 import com.twitter.finatra.http.routing.HttpRouter
 import com.twitter.inject.TwitterModule
-import com.twitter.inject.requestscope.FinagleRequestScopeFilter
 import net.spals.appbuilder.app.core.matcher.TypeLiteralMatchers
 import net.spals.appbuilder.graph.model.ServiceGraph
 
@@ -19,8 +17,6 @@ import scala.collection.mutable.ListBuffer
   */
 private[finatra] case class FinatraWebServerModule(
     serviceGraph: ServiceGraph,
-    addCommonFilters: Boolean = true,
-    addRequestScopeFilter: Boolean = false,
     runWebServerAutoBinding: Boolean = true
   ) extends TwitterModule
   with InjectionListener[AnyRef]
@@ -66,9 +62,6 @@ private[finatra] case class FinatraWebServerModule(
       info(s"Binding filter: ${filter.getClass}")
       router.filter(filter)
     })
-    Option(addCommonFilters).filter(b => b).foreach(router.filter[CommonFilters])
-    Option(addRequestScopeFilter).filter(b => b).foreach(
-      router.filter[FinagleRequestScopeFilter[finaglehttp.Request, finaglehttp.Response]])
 
     exceptionMappers.toList.foreach(exceptionMapper => {
       info(s"Binding exception mapper: ${exceptionMapper.getClass}")

--- a/app-finatra/src/main/scala/net/spals/appbuilder/app/finatra/monitor/FinatraTracingFilter.scala
+++ b/app-finatra/src/main/scala/net/spals/appbuilder/app/finatra/monitor/FinatraTracingFilter.scala
@@ -1,0 +1,71 @@
+package net.spals.appbuilder.app.finatra.monitor
+
+import javax.ws.rs.core.MultivaluedHashMap
+
+import com.twitter.finagle.Service
+import com.twitter.finagle.SimpleFilter
+import com.twitter.finagle.http.Request
+import com.twitter.finagle.http.Response
+import com.twitter.finagle.http.Status
+import com.twitter.util.Future
+import com.twitter.util.Return
+import com.twitter.util.Throw
+import io.opentracing.Span
+import io.opentracing.SpanContext
+import io.opentracing.Tracer
+import io.opentracing.contrib.jaxrs2.server.ServerHeadersExtractTextMap
+import io.opentracing.propagation.Format
+import io.opentracing.tag.Tags
+
+import scala.collection.JavaConverters._
+
+/**
+  * A web [[com.twitter.finagle.Filter]] which
+  * automatically activates request tracing
+  * using an OpenTracing [[Tracer]] instance.
+  *
+  * This is modeled off of [[io.opentracing.contrib.jaxrs2.server.ServerTracingFilter]]
+  *
+  * NOTE: This is not to be confused with a
+  * Finagle [[com.twitter.finagle.tracing.Tracer]]
+  * and the related infrastructure.
+  */
+private[finatra] class FinatraTracingFilter (
+  tracer: Tracer
+) extends SimpleFilter[Request, Response] {
+
+  override def apply(
+    request: Request,
+    service: Service[Request, Response]
+  ): Future[Response] = {
+    val headerMap = new MultivaluedHashMap[String, String](request.headerMap.asJava)
+    val extractedSpanContext: SpanContext = tracer.extract(Format.Builtin.HTTP_HEADERS,
+      new ServerHeadersExtractTextMap(headerMap))
+
+    val spanBuilder = tracer.buildSpan(request.path)
+      .withTag(Tags.SPAN_KIND.getKey, Tags.SPAN_KIND_SERVER)
+      .withTag(Tags.HTTP_METHOD.getKey, request.method.name)
+      .withTag(Tags.HTTP_URL.getKey, request.uri)
+
+    Option(extractedSpanContext).foreach(spanBuilder.asChildOf(_))
+
+    val span = spanBuilder.startManual()
+    tracer.makeActive(span)
+
+    service(request).respond {
+      case Return(response) =>
+        Tags.HTTP_STATUS.set(span, response.statusCode)
+        finishSpan(span)
+      case Throw(e) =>
+        Tags.HTTP_STATUS.set(span, Status.InternalServerError.code)
+        finishSpan(span)
+    }
+  }
+
+  private[finatra] def finishSpan(span: Span): Unit = {
+    Option(tracer.activeSpan()) match {
+      case Some(activeSpan) => activeSpan.deactivate()
+      case None => span.finish()
+    }
+  }
+}

--- a/executor-core-test/pom.xml
+++ b/executor-core-test/pom.xml
@@ -9,34 +9,38 @@
 
     <modelVersion>4.0.0</modelVersion>
     <groupId>net.spals.appbuilder</groupId>
-    <artifactId>spals-appbuilder-executor-core</artifactId>
+    <artifactId>spals-appbuilder-executor-core-test</artifactId>
     <version>0.0.4-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <dependencies>
         <dependency>
-            <groupId>ch.qos.logback</groupId>
-            <artifactId>logback-classic</artifactId>
+            <groupId>eu.codearte.catch-exception</groupId>
+            <artifactId>catch-exception</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.netflix.governator</groupId>
-            <artifactId>governator-api</artifactId>
+            <groupId>eu.codearte.catch-exception</groupId>
+            <artifactId>catch-throwable</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.opentracing.contrib</groupId>
-            <artifactId>opentracing-concurrent</artifactId>
+            <groupId>io.opentracing</groupId>
+            <artifactId>opentracing-mock</artifactId>
         </dependency>
         <dependency>
             <groupId>net.spals.appbuilder</groupId>
-            <artifactId>spals-appbuilder-annotations</artifactId>
+            <artifactId>spals-appbuilder-executor-core</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.inferred</groupId>
-            <artifactId>freebuilder</artifactId>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>java-hamcrest</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-api</artifactId>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.testng</groupId>
+            <artifactId>testng</artifactId>
         </dependency>
     </dependencies>
 

--- a/executor-core-test/src/test/java/net/spals/appbuilder/executor/core/DefaultExecutorServiceFactoryTest.java
+++ b/executor-core-test/src/test/java/net/spals/appbuilder/executor/core/DefaultExecutorServiceFactoryTest.java
@@ -1,0 +1,146 @@
+package net.spals.appbuilder.executor.core;
+
+import io.opentracing.mock.MockSpan;
+import io.opentracing.mock.MockTracer;
+import org.testng.annotations.Test;
+
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+/**
+ * Unit tests for {@link DefaultExecutorServiceFactory}
+ *
+ * @author tkral
+ */
+public class DefaultExecutorServiceFactoryTest {
+
+    @Test
+    public void testCreateFixedThreadPool() {
+        final ExecutorServiceFactory executorServiceFactory = new DefaultExecutorServiceFactory(new MockTracer());
+
+        final ExecutorService executorService =
+                executorServiceFactory.createFixedThreadPool(2 /*nThreads*/, this.getClass());
+        assertThat(executorService, instanceOf(StoppableExecutorService.class));
+
+        final StoppableExecutorService stoppableExecutorService =
+                (StoppableExecutorService)executorService;
+        assertThat(stoppableExecutorService.getDelegate(), instanceOf(TraceableExecutorService.class));
+        assertThat(stoppableExecutorService.getShutdown(), is(1000L));
+        assertThat(stoppableExecutorService.getShutdownUnit(), is(TimeUnit.MILLISECONDS));
+
+        final TraceableExecutorService traceableExecutorService =
+                (TraceableExecutorService)stoppableExecutorService.getDelegate();
+        final ThreadPoolExecutor threadPoolExecutor = (ThreadPoolExecutor)traceableExecutorService.getDelegate();
+        assertThat(threadPoolExecutor.getCorePoolSize(), is(2));
+        assertThat(threadPoolExecutor.getMaximumPoolSize(), is(2));
+        assertThat(threadPoolExecutor.getKeepAliveTime(TimeUnit.MILLISECONDS), is(0L));
+    }
+
+    @Test
+    public void testCreateCachedThreadPool() {
+        final ExecutorServiceFactory executorServiceFactory = new DefaultExecutorServiceFactory(new MockTracer());
+
+        final ExecutorService executorService =
+                executorServiceFactory.createCachedThreadPool(this.getClass());
+        assertThat(executorService, instanceOf(StoppableExecutorService.class));
+
+        final StoppableExecutorService stoppableExecutorService =
+                (StoppableExecutorService)executorService;
+        assertThat(stoppableExecutorService.getDelegate(), instanceOf(TraceableExecutorService.class));
+        assertThat(stoppableExecutorService.getShutdown(), is(1000L));
+        assertThat(stoppableExecutorService.getShutdownUnit(), is(TimeUnit.MILLISECONDS));
+
+        final TraceableExecutorService traceableExecutorService =
+                (TraceableExecutorService)stoppableExecutorService.getDelegate();
+        final ThreadPoolExecutor threadPoolExecutor = (ThreadPoolExecutor)traceableExecutorService.getDelegate();
+        assertThat(threadPoolExecutor.getCorePoolSize(), is(0));
+        assertThat(threadPoolExecutor.getMaximumPoolSize(), is(Integer.MAX_VALUE));
+        assertThat(threadPoolExecutor.getKeepAliveTime(TimeUnit.SECONDS), is(60L));
+    }
+
+    @Test
+    public void testCreateSingleThreadExecutor() {
+        final ExecutorServiceFactory executorServiceFactory = new DefaultExecutorServiceFactory(new MockTracer());
+
+        final ExecutorService executorService =
+                executorServiceFactory.createSingleThreadExecutor(this.getClass());
+        assertThat(executorService, instanceOf(StoppableExecutorService.class));
+
+        final StoppableExecutorService stoppableExecutorService =
+                (StoppableExecutorService)executorService;
+        assertThat(stoppableExecutorService.getShutdown(), is(1000L));
+        assertThat(stoppableExecutorService.getShutdownUnit(), is(TimeUnit.MILLISECONDS));
+
+        // Unable to add more assertions because single thread executor uses a private type
+    }
+
+    @Test
+    public void testRegisterFixedThreadPool() {
+        final DefaultExecutorServiceFactory executorServiceFactory = new DefaultExecutorServiceFactory(new MockTracer());
+
+        final ExecutorService executorService =
+            executorServiceFactory.createFixedThreadPool(2 /*nThreads*/, this.getClass());
+        final ExecutorServiceFactory.Key expectedKey = new ExecutorServiceFactory.Key.Builder()
+                .setParentClass(this.getClass()).build();
+
+        assertThat(executorServiceFactory.getStoppableExecutorServices(),
+                hasEntry(is(expectedKey), sameInstance(executorService)));
+    }
+
+    @Test
+    public void testRegisterCachedThreadPool() {
+        final DefaultExecutorServiceFactory executorServiceFactory = new DefaultExecutorServiceFactory(new MockTracer());
+
+        final ExecutorService executorService =
+                executorServiceFactory.createCachedThreadPool(this.getClass());
+        final ExecutorServiceFactory.Key expectedKey = new ExecutorServiceFactory.Key.Builder()
+                .setParentClass(this.getClass()).build();
+
+        assertThat(executorServiceFactory.getStoppableExecutorServices(),
+                hasEntry(is(expectedKey), sameInstance(executorService)));
+    }
+
+    @Test
+    public void testRegisterSingleThreadExecutor() {
+        final DefaultExecutorServiceFactory executorServiceFactory = new DefaultExecutorServiceFactory(new MockTracer());
+
+        final ExecutorService executorService =
+                executorServiceFactory.createSingleThreadExecutor(this.getClass());
+        final ExecutorServiceFactory.Key expectedKey = new ExecutorServiceFactory.Key.Builder()
+                .setParentClass(this.getClass()).build();
+
+        assertThat(executorServiceFactory.getStoppableExecutorServices(),
+                hasEntry(is(expectedKey), sameInstance(executorService)));
+    }
+
+    @Test
+    public void testStop() {
+        final DefaultExecutorServiceFactory executorServiceFactory = new DefaultExecutorServiceFactory(new MockTracer());
+
+        final StoppableExecutorService executorService1 = mock(StoppableExecutorService.class);
+        final ExecutorServiceFactory.Key key1 = new ExecutorServiceFactory.Key.Builder()
+                .setParentClass(this.getClass())
+                .addTags("1")
+                .build();
+        final StoppableExecutorService executorService2 = mock(StoppableExecutorService.class);
+        final ExecutorServiceFactory.Key key2 = new ExecutorServiceFactory.Key.Builder()
+                .setParentClass(this.getClass())
+                .addTags("2")
+                .build();
+
+        executorServiceFactory.getStoppableExecutorServices().put(key1, executorService1);
+        executorServiceFactory.getStoppableExecutorServices().put(key2, executorService2);
+
+        executorServiceFactory.stop();
+        verify(executorService1).stop();
+        verify(executorService2).stop();
+    }
+}

--- a/executor-core-test/src/test/java/net/spals/appbuilder/executor/core/StoppableExecutorServiceTest.java
+++ b/executor-core-test/src/test/java/net/spals/appbuilder/executor/core/StoppableExecutorServiceTest.java
@@ -1,0 +1,103 @@
+package net.spals.appbuilder.executor.core;
+
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.Mockito.*;
+
+/**
+ * Unit tests for {@link StoppableExecutorService}.
+ *
+ * @author tkral
+ */
+public class StoppableExecutorServiceTest {
+
+    @DataProvider
+    Object[][] loggerNameProvider() {
+        return new Object[][] {
+                // Case: No tags
+                {new ExecutorServiceFactory.Key.Builder()
+                        .setParentClass(this.getClass())
+                        .build(),
+                    "net.spals.appbuilder.executor.core.StoppableExecutorServiceTest[]"},
+                // Case: Single tag
+                {new ExecutorServiceFactory.Key.Builder()
+                        .setParentClass(this.getClass())
+                        .addTags("myTag")
+                        .build(),
+                        "net.spals.appbuilder.executor.core.StoppableExecutorServiceTest[myTag]"},
+                // Case: Multiple tags
+                {new ExecutorServiceFactory.Key.Builder()
+                        .setParentClass(this.getClass())
+                        .addTags("myTag1", "myTag2")
+                        .build(),
+                        "net.spals.appbuilder.executor.core.StoppableExecutorServiceTest[myTag1,myTag2]"},
+        };
+    }
+
+    @Test(dataProvider = "loggerNameProvider")
+    public void testLoggerName(final ExecutorServiceFactory.Key executorServiceKey,
+                               final String expectedLoggerName) {
+        final ExecutorService executorService = Executors.newSingleThreadExecutor();
+        final StoppableExecutorService stoppableExecutorService =
+            new StoppableExecutorService(executorService, executorServiceKey, 1L, TimeUnit.SECONDS);
+
+        assertThat(stoppableExecutorService.getLogger().getName(), is(expectedLoggerName));
+    }
+
+    @Test
+    public void testStopAlreadyShutdown() {
+        final ExecutorService executorService = mock(ExecutorService.class);
+        when(executorService.isShutdown()).thenReturn(true);
+
+        final ExecutorServiceFactory.Key executorServiceKey = new ExecutorServiceFactory.Key.Builder()
+            .setParentClass(this.getClass())
+            .build();
+        final StoppableExecutorService stoppableExecutorService =
+             new StoppableExecutorService(executorService, executorServiceKey, 1L, TimeUnit.SECONDS);
+
+        stoppableExecutorService.stop();
+        verify(executorService, never()).shutdown();
+        verify(executorService, never()).shutdownNow();
+    }
+
+    @Test
+    public void testStopNoTermination() throws InterruptedException {
+        final ExecutorService executorService = mock(ExecutorService.class);
+        when(executorService.isShutdown()).thenReturn(false);
+        when(executorService.awaitTermination(anyLong(), any(TimeUnit.class))).thenReturn(false,true);
+
+        final ExecutorServiceFactory.Key executorServiceKey = new ExecutorServiceFactory.Key.Builder()
+                .setParentClass(this.getClass())
+                .build();
+        final StoppableExecutorService stoppableExecutorService =
+            new StoppableExecutorService(executorService, executorServiceKey, 1L, TimeUnit.SECONDS);
+
+        stoppableExecutorService.stop();
+        verify(executorService).shutdown();
+        verify(executorService).shutdownNow();
+    }
+
+    @Test
+    public void testStopErrorTermination() throws InterruptedException {
+        final ExecutorService executorService = mock(ExecutorService.class);
+        when(executorService.isShutdown()).thenReturn(false);
+        when(executorService.awaitTermination(anyLong(), any(TimeUnit.class))).thenThrow(new InterruptedException());
+
+        final ExecutorServiceFactory.Key executorServiceKey = new ExecutorServiceFactory.Key.Builder()
+                .setParentClass(this.getClass())
+                .build();
+        final StoppableExecutorService stoppableExecutorService =
+            new StoppableExecutorService(executorService, executorServiceKey, 1L, TimeUnit.SECONDS);
+
+        stoppableExecutorService.stop();
+        verify(executorService).shutdown();
+        verify(executorService).shutdownNow();
+    }
+}

--- a/executor-core/src/main/java/net/spals/appbuilder/executor/core/TraceableExecutorService.java
+++ b/executor-core/src/main/java/net/spals/appbuilder/executor/core/TraceableExecutorService.java
@@ -1,0 +1,101 @@
+package net.spals.appbuilder.executor.core;
+
+import com.google.common.annotations.VisibleForTesting;
+import io.opentracing.Tracer;
+import io.opentracing.contrib.concurrent.TracedExecutorService;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.concurrent.*;
+
+/**
+ * An {@link ExecutorService} delegater which provides
+ * asynchronous tracing a {@link Tracer} object.
+ *
+ * @author tkral
+ */
+class TraceableExecutorService implements ExecutorService {
+
+    private final ExecutorService delegate;
+    private final TracedExecutorService tracedDelegate;
+
+    TraceableExecutorService(final ExecutorService delegate,
+                             final Tracer tracer) {
+        this.delegate = delegate;
+        this.tracedDelegate = new TracedExecutorService(delegate, tracer);
+    }
+
+    @Override
+    public boolean awaitTermination(final long timeout, final TimeUnit unit) throws InterruptedException {
+        return tracedDelegate.awaitTermination(timeout, unit);
+    }
+
+    @Override
+    public void execute(final Runnable command) {
+        tracedDelegate.execute(command);
+    }
+
+    @VisibleForTesting
+    ExecutorService getDelegate() {
+        return delegate;
+    }
+
+    @Override
+    public <T> List<Future<T>> invokeAll(final Collection<? extends Callable<T>> tasks) throws InterruptedException {
+        return tracedDelegate.invokeAll(tasks);
+    }
+
+    @Override
+    public <T> List<Future<T>> invokeAll(final Collection<? extends Callable<T>> tasks,
+                                         final long timeout,
+                                         final TimeUnit unit) throws InterruptedException {
+        return tracedDelegate.invokeAll(tasks, timeout, unit);
+    }
+
+    @Override
+    public <T> T invokeAny(final Collection<? extends Callable<T>> tasks) throws InterruptedException, ExecutionException {
+        return tracedDelegate.invokeAny(tasks);
+    }
+
+    @Override
+    public <T> T invokeAny(final Collection<? extends Callable<T>> tasks,
+                           final long timeout,
+                           final TimeUnit unit) throws InterruptedException, ExecutionException, TimeoutException {
+        return tracedDelegate.invokeAny(tasks, timeout, unit);
+    }
+
+    @Override
+    public boolean isShutdown() {
+        return tracedDelegate.isShutdown();
+    }
+
+    @Override
+    public boolean isTerminated() {
+        return tracedDelegate.isTerminated();
+    }
+
+    @Override
+    public void shutdown() {
+        tracedDelegate.shutdown();
+    }
+
+    @Override
+    public List<Runnable> shutdownNow() {
+        return tracedDelegate.shutdownNow();
+    }
+
+    @Override
+    public <T> Future<T> submit(final Callable<T> task) {
+        return tracedDelegate.submit(task);
+    }
+
+    @Override
+    public <T> Future<T> submit(final Runnable task, final T result) {
+        return tracedDelegate.submit(task, result);
+    }
+
+    @Override
+    public Future<?> submit(final Runnable task) {
+        return tracedDelegate.submit(task);
+    }
+}

--- a/filestore-s3-test/src/test/scala/net/spals/appbuilder/filestore/s3/S3FileStorePluginIT.scala
+++ b/filestore-s3-test/src/test/scala/net/spals/appbuilder/filestore/s3/S3FileStorePluginIT.scala
@@ -16,7 +16,7 @@ import net.spals.appbuilder.filestore.core.model._
 import net.spals.appbuilder.filestore.s3.S3SpanMatcher.s3Span
 import org.hamcrest.MatcherAssert._
 import org.hamcrest.Matchers._
-import org.hamcrest.{Description, Matchers, TypeSafeMatcher}
+import org.hamcrest.{Description, TypeSafeMatcher}
 import org.mockito.ArgumentMatchers.{any => m_any, anyInt => m_anyInt}
 import org.mockito.Mockito.{mock, when}
 import org.slf4j.LoggerFactory
@@ -162,10 +162,10 @@ private object S3SpanMatcher {
 private case class S3SpanMatcher(url: String, method: String) extends TypeSafeMatcher[MockSpan] {
 
   override def matchesSafely(mockSpan: MockSpan): Boolean = {
-    Matchers.hasEntry[String, AnyRef]("component", "java-aws-sdk").matches(mockSpan.tags()) &&
-      Matchers.hasEntry[String, AnyRef]("http.method", method).matches(mockSpan.tags()) &&
-      Matchers.hasEntry[String, AnyRef]("http.url", url).matches(mockSpan.tags()) &&
-      Matchers.hasEntry[String, AnyRef]("span.kind", "client").matches(mockSpan.tags()) &&
+    hasEntry[String, AnyRef]("component", "java-aws-sdk").matches(mockSpan.tags()) &&
+      hasEntry[String, AnyRef]("http.method", method).matches(mockSpan.tags()) &&
+      hasEntry[String, AnyRef]("http.url", url).matches(mockSpan.tags()) &&
+      hasEntry[String, AnyRef]("span.kind", "client").matches(mockSpan.tags()) &&
       "Amazon S3".equals(mockSpan.operationName())
   }
 

--- a/mapstore-cassandra-test/pom.xml
+++ b/mapstore-cassandra-test/pom.xml
@@ -27,6 +27,10 @@
             <artifactId>catch-throwable</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.opentracing</groupId>
+            <artifactId>opentracing-mock</artifactId>
+        </dependency>
+        <dependency>
             <groupId>net.spals.appbuilder.plugins</groupId>
             <artifactId>spals-appbuilder-mapstore-cassandra</artifactId>
         </dependency>

--- a/mapstore-cassandra/pom.xml
+++ b/mapstore-cassandra/pom.xml
@@ -23,6 +23,10 @@
             <artifactId>governator-api</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.opentracing.contrib</groupId>
+            <artifactId>opentracing-cassandra-driver</artifactId>
+        </dependency>
+        <dependency>
             <groupId>javax.validation</groupId>
             <artifactId>validation-api</artifactId>
         </dependency>
@@ -37,6 +41,10 @@
         <dependency>
             <groupId>net.spals.appbuilder</groupId>
             <artifactId>spals-appbuilder-mapstore-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>net.spals.appbuilder</groupId>
+            <artifactId>spals-appbuilder-monitor-core</artifactId>
         </dependency>
         <dependency>
             <groupId>org.scala-lang</groupId>

--- a/mapstore-cassandra/src/main/scala/net/spals/appbuilder/mapstore/cassandra/CassandraClusterProvider.scala
+++ b/mapstore-cassandra/src/main/scala/net/spals/appbuilder/mapstore/cassandra/CassandraClusterProvider.scala
@@ -3,6 +3,8 @@ package net.spals.appbuilder.mapstore.cassandra
 import com.datastax.driver.core.Cluster
 import com.datastax.driver.core.Cluster.Initializer
 import com.google.inject.{Inject, Provider}
+import io.opentracing.Tracer
+import io.opentracing.contrib.cassandra.TracingCluster
 import net.spals.appbuilder.annotations.service.AutoBindProvider
 
 /**
@@ -12,10 +14,11 @@ import net.spals.appbuilder.annotations.service.AutoBindProvider
   */
 @AutoBindProvider
 private[cassandra] class CassandraClusterProvider @Inject()(
-  initializer: Initializer
+  initializer: Initializer,
+  tracer: Tracer
 ) extends Provider[Cluster] {
 
   override def get(): Cluster = {
-    Cluster.buildFrom(initializer)
+    new TracingCluster(initializer, tracer)
   }
 }

--- a/mapstore-dynamodb-test/src/test/scala/net/spals/appbuilder/mapstore/dynamodb/DynamoDBMapStorePluginIT.scala
+++ b/mapstore-dynamodb-test/src/test/scala/net/spals/appbuilder/mapstore/dynamodb/DynamoDBMapStorePluginIT.scala
@@ -10,8 +10,8 @@ import net.spals.appbuilder.mapstore.core.model.ZeroValueMapRangeKey.all
 import net.spals.appbuilder.mapstore.core.model.{MapStoreKey, MapStoreTableKey}
 import net.spals.appbuilder.mapstore.dynamodb.DynamoDBSpanMatcher.dynamoDBSpan
 import org.hamcrest.MatcherAssert.assertThat
-import org.hamcrest.Matchers.{contains, empty, is}
-import org.hamcrest.{Description, Matchers, TypeSafeMatcher}
+import org.hamcrest.Matchers.{contains, empty, hasEntry, is}
+import org.hamcrest.{Description, TypeSafeMatcher}
 import org.slf4j.LoggerFactory
 import org.testng.annotations._
 
@@ -206,10 +206,10 @@ private object DynamoDBSpanMatcher {
 private case class DynamoDBSpanMatcher(url: String, method: String) extends TypeSafeMatcher[MockSpan] {
 
   override def matchesSafely(mockSpan: MockSpan): Boolean = {
-    Matchers.hasEntry[String, AnyRef]("component", "java-aws-sdk").matches(mockSpan.tags()) &&
-      Matchers.hasEntry[String, AnyRef]("http.method", method).matches(mockSpan.tags()) &&
-      Matchers.hasEntry[String, AnyRef]("http.url", url).matches(mockSpan.tags()) &&
-      Matchers.hasEntry[String, AnyRef]("span.kind", "client").matches(mockSpan.tags()) &&
+    hasEntry[String, AnyRef]("component", "java-aws-sdk").matches(mockSpan.tags()) &&
+      hasEntry[String, AnyRef]("http.method", method).matches(mockSpan.tags()) &&
+      hasEntry[String, AnyRef]("http.url", url).matches(mockSpan.tags()) &&
+      hasEntry[String, AnyRef]("span.kind", "client").matches(mockSpan.tags()) &&
       "AmazonDynamoDBv2".equals(mockSpan.operationName())
   }
 

--- a/pom.xml
+++ b/pom.xml
@@ -93,6 +93,7 @@
         <module>config</module>
         <module>config-test</module>
         <module>executor-core</module>
+        <module>executor-core-test</module>
         <module>filestore-core</module>
         <module>filestore-core-test</module>
         <module>filestore-s3</module>

--- a/pom.xml
+++ b/pom.xml
@@ -71,6 +71,7 @@
         <logback.version>1.2.1</logback.version>
         <mapdb.version>3.0.3</mapdb.version>
         <opentracing.aws.version>0.0.2</opentracing.aws.version>
+        <opentracing.cassandra.version>0.0.2</opentracing.cassandra.version>
         <opentracing.concurrent.version>0.0.2</opentracing.concurrent.version>
         <opentracing.jaxrs2.version>0.0.9</opentracing.jaxrs2.version>
         <opentracing.version>0.30.0</opentracing.version>
@@ -311,6 +312,11 @@
                         <artifactId>aws-java-sdk</artifactId>
                     </exclusion>
                 </exclusions>
+            </dependency>
+            <dependency>
+                <groupId>io.opentracing.contrib</groupId>
+                <artifactId>opentracing-cassandra-driver</artifactId>
+                <version>${opentracing.cassandra.version}</version>
             </dependency>
             <dependency>
                 <groupId>io.opentracing.contrib</groupId>


### PR DESCRIPTION
Related to #20 . This PR includes:

1. New `executor-core-test` module with unit tests for `ExecutorServiceFactory` (including for tracing).
2. OpenTracing support for Finatra. This is modeled off of the [filter in the OpenTracing JaxRs integration](https://github.com/opentracing-contrib/java-jaxrs/blob/master/opentracing-jaxrs2/src/main/java/io/opentracing/contrib/jaxrs2/server/ServerTracingFilter.java). This includes tests for tracing.
3. Adds [OpenTracing integration with Cassandra](https://github.com/opentracing-contrib/java-cassandra-driver), including testing.