### PR TITLE
More tests for better code coverage

### DIFF
--- a/executor-core-test/src/test/java/net/spals/appbuilder/executor/core/StoppableExecutorServiceTest.java
+++ b/executor-core-test/src/test/java/net/spals/appbuilder/executor/core/StoppableExecutorServiceTest.java
@@ -3,6 +3,7 @@ package net.spals.appbuilder.executor.core;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
+import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
@@ -99,5 +100,65 @@ public class StoppableExecutorServiceTest {
         stoppableExecutorService.stop();
         verify(executorService).shutdown();
         verify(executorService).shutdownNow();
+    }
+
+    @Test
+    public void testExecute() throws InterruptedException {
+        final ExecutorService delegate = mock(ExecutorService.class);
+
+        final ExecutorServiceFactory.Key executorServiceKey = new ExecutorServiceFactory.Key.Builder()
+                .setParentClass(this.getClass())
+                .build();
+        final StoppableExecutorService stoppableExecutorService =
+                new StoppableExecutorService(delegate, executorServiceKey, 1L, TimeUnit.SECONDS);
+
+        final Runnable r = () -> {};
+        stoppableExecutorService.execute(r);
+        verify(delegate).execute(same(r));
+    }
+
+    @Test
+    public void testSubmitCallable() {
+        final ExecutorService delegate = mock(ExecutorService.class);
+
+        final ExecutorServiceFactory.Key executorServiceKey = new ExecutorServiceFactory.Key.Builder()
+                .setParentClass(this.getClass())
+                .build();
+        final StoppableExecutorService stoppableExecutorService =
+                new StoppableExecutorService(delegate, executorServiceKey, 1L, TimeUnit.SECONDS);
+
+        final Callable<Void> c = () -> (Void)null;
+        stoppableExecutorService.submit(c);
+        verify(delegate).submit(same(c));
+    }
+
+    @Test
+    public void testSubmitRunnable() {
+        final ExecutorService delegate = mock(ExecutorService.class);
+
+        final ExecutorServiceFactory.Key executorServiceKey = new ExecutorServiceFactory.Key.Builder()
+                .setParentClass(this.getClass())
+                .build();
+        final StoppableExecutorService stoppableExecutorService =
+                new StoppableExecutorService(delegate, executorServiceKey, 1L, TimeUnit.SECONDS);
+
+        final Runnable r = () -> {};
+        stoppableExecutorService.submit(r);
+        verify(delegate).submit(same(r));
+    }
+
+    @Test
+    public void testSubmitRunnableResult() {
+        final ExecutorService delegate = mock(ExecutorService.class);
+
+        final ExecutorServiceFactory.Key executorServiceKey = new ExecutorServiceFactory.Key.Builder()
+                .setParentClass(this.getClass())
+                .build();
+        final StoppableExecutorService stoppableExecutorService =
+                new StoppableExecutorService(delegate, executorServiceKey, 1L, TimeUnit.SECONDS);
+
+        final Runnable r = () -> {};
+        stoppableExecutorService.submit(r, 1L);
+        verify(delegate).submit(same(r), eq(1L));
     }
 }

--- a/executor-core-test/src/test/java/net/spals/appbuilder/executor/core/TraceableExecutorServiceTest.java
+++ b/executor-core-test/src/test/java/net/spals/appbuilder/executor/core/TraceableExecutorServiceTest.java
@@ -1,0 +1,68 @@
+package net.spals.appbuilder.executor.core;
+
+import io.opentracing.contrib.concurrent.TracedCallable;
+import io.opentracing.contrib.concurrent.TracedRunnable;
+import io.opentracing.mock.MockTracer;
+import org.testng.annotations.Test;
+
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutorService;
+
+import static org.mockito.Mockito.*;
+
+/**
+ * Unit tests for {@link TraceableExecutorService}.
+ *
+ * @author tkral
+ */
+public class TraceableExecutorServiceTest {
+
+    @Test
+    public void testExecute() throws InterruptedException {
+        final ExecutorService delegate = mock(ExecutorService.class);
+
+        final MockTracer tracer = new MockTracer();
+        final TraceableExecutorService traceableExecutorService = new TraceableExecutorService(delegate, tracer);
+
+        final Runnable r = () -> {};
+        traceableExecutorService.execute(r);
+
+        verify(delegate).execute(isA(TracedRunnable.class));
+    }
+
+    @Test
+    public void testSubmitCallable() {
+        final ExecutorService delegate = mock(ExecutorService.class);
+
+        final MockTracer tracer = new MockTracer();
+        final TraceableExecutorService traceableExecutorService = new TraceableExecutorService(delegate, tracer);
+
+        final Callable<Void> c = () -> (Void)null;
+        traceableExecutorService.submit(c);
+        verify(delegate).submit(isA(TracedCallable.class));
+    }
+
+    @Test
+    public void testSubmitRunnable() {
+        final ExecutorService delegate = mock(ExecutorService.class);
+
+        final MockTracer tracer = new MockTracer();
+        final TraceableExecutorService traceableExecutorService = new TraceableExecutorService(delegate, tracer);
+
+        final Runnable r = () -> {};
+        traceableExecutorService.submit(r);
+        verify(delegate).submit(isA(TracedRunnable.class));
+    }
+
+    @Test
+    public void testSubmitRunnableResult() {
+        final ExecutorService delegate = mock(ExecutorService.class);
+
+        final MockTracer tracer = new MockTracer();
+        final TraceableExecutorService traceableExecutorService = new TraceableExecutorService(delegate, tracer);
+
+        final Runnable r = () -> {};
+        traceableExecutorService.submit(r, 1L);
+        verify(delegate).submit(isA(TracedRunnable.class), eq(1L));
+    }
+}

--- a/filestore-core-test/src/test/java/net/spals/appbuilder/filestore/core/localfs/LocalFSFileStorePluginFTest.java
+++ b/filestore-core-test/src/test/java/net/spals/appbuilder/filestore/core/localfs/LocalFSFileStorePluginFTest.java
@@ -41,7 +41,9 @@ public class LocalFSFileStorePluginFTest {
         assertThat(fileMetadata.getURI().getPath(),
                 is(String.format("%s/LocalFSFileStorePluginFTest/testPutFile.txt", basePath)));
         assertThat(fileMetadata.getSecurityLevel(), is(FileSecurityLevel.PUBLIC));
+        assertThat(fileMetadata.getSecurityLevel().isPublic(), is(true));
         assertThat(fileMetadata.getStoreLocation(), is(FileStoreLocation.LOCAL));
+        assertThat(fileMetadata.getStoreLocation().isLocal(), is(true));
         assertThat(java.nio.file.Files.getPosixFilePermissions(Paths.get(fileMetadata.getURI())), hasItem(OTHERS_READ));
     }
 
@@ -122,5 +124,6 @@ public class LocalFSFileStorePluginFTest {
 
         assertThat(java.nio.file.Files.getPosixFilePermissions(Paths.get(fileMetadata.getURI())), not(hasItem(OTHERS_READ)));
         assertThat(fileStorePlugin.getFileMetadata(fileKey).get().getSecurityLevel(), is(FileSecurityLevel.PRIVATE));
+        assertThat(fileStorePlugin.getFileMetadata(fileKey).get().getSecurityLevel().isPrivate(), is(true));
     }
 }

--- a/filestore-s3-test/src/test/scala/net/spals/appbuilder/filestore/s3/S3FileStorePluginIT.scala
+++ b/filestore-s3-test/src/test/scala/net/spals/appbuilder/filestore/s3/S3FileStorePluginIT.scala
@@ -90,7 +90,9 @@ class S3FileStorePluginIT {
 
     assertThat(fileMetadata.getURI, hasToString[URI](s"${s3ClientProvider.endpoint}/s3filestorepluginit-filestore/S3FileStorePluginIT/testPutFile.txt"))
     assertThat(fileMetadata.getSecurityLevel, is(FileSecurityLevel.PUBLIC))
+    assertThat(fileMetadata.getSecurityLevel.isPublic, is(true))
     assertThat(fileMetadata.getStoreLocation, is(FileStoreLocation.REMOTE))
+    assertThat(fileMetadata.getStoreLocation.isRemote, is(true))
     assertThat(s3Tracer.finishedSpans(), contains[MockSpan](s3Span(s3Endpoint, "PUT")))
   }
 

--- a/mapstore-cassandra-test/src/test/scala/net/spals/appbuilder/mapstore/cassandra/CassandraMapStorePluginIT.scala
+++ b/mapstore-cassandra-test/src/test/scala/net/spals/appbuilder/mapstore/cassandra/CassandraMapStorePluginIT.scala
@@ -66,6 +66,10 @@ class CassandraMapStorePluginIT {
     mapStorePlugin.close()
   }
 
+  @Test def testCreateTableIdempotent() {
+    assertThat(mapStorePlugin.createTable(hashTableName, hashTableKey), is(true))
+  }
+
   @DataProvider def emptyGetProvider(): Array[Array[AnyRef]] = {
     Array(
       // Case: Hash-only key

--- a/mapstore-cassandra/src/main/scala/net/spals/appbuilder/mapstore/cassandra/CassandraMapStorePlugin.scala
+++ b/mapstore-cassandra/src/main/scala/net/spals/appbuilder/mapstore/cassandra/CassandraMapStorePlugin.scala
@@ -3,7 +3,7 @@ package net.spals.appbuilder.mapstore.cassandra
 import java.io.Closeable
 import java.util.{Date, Optional, UUID}
 import javax.annotation.PreDestroy
-import javax.validation.constraints.{Min, NotNull}
+import javax.validation.constraints.Min
 
 import com.datastax.driver.core._
 import com.datastax.driver.core.querybuilder.QueryBuilder
@@ -73,7 +73,11 @@ private[cassandra] class CassandraMapStorePlugin @Inject() (
       .foreach(schemaBuilder.addClusteringColumn(_, loadDataType(tableKey.getRangeFieldType.get())))
     schemaBuilder.addColumn("payload", DataType.map(DataType.varchar(), DataType.varchar()))
 
-    session.execute(schemaBuilder.toString).wasApplied()
+    try {
+      session.execute(schemaBuilder.toString).wasApplied()
+    } catch {
+      case _: RuntimeException => false
+    }
   }
 
   override def dropTable(tableName: String): Boolean = {

--- a/mapstore-core-test/src/test/java/net/spals/appbuilder/mapstore/core/DelegatingMapStoreTest.java
+++ b/mapstore-core-test/src/test/java/net/spals/appbuilder/mapstore/core/DelegatingMapStoreTest.java
@@ -1,0 +1,246 @@
+package net.spals.appbuilder.mapstore.core;
+
+import net.spals.appbuilder.mapstore.core.MapStoreProvider.DelegatingMapStore;
+import net.spals.appbuilder.mapstore.core.model.MapQueryOptions;
+import net.spals.appbuilder.mapstore.core.model.MapQueryOptions.Order;
+import net.spals.appbuilder.mapstore.core.model.MapStoreKey;
+import net.spals.appbuilder.mapstore.core.model.MapStoreTableKey;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static com.googlecode.catchexception.CatchException.*;
+import static net.spals.appbuilder.mapstore.core.model.SingleValueMapRangeKey.equalTo;
+import static net.spals.appbuilder.mapstore.core.model.SingleValueMapRangeKey.greaterThan;
+import static net.spals.appbuilder.mapstore.core.model.ZeroValueMapRangeKey.*;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.same;
+import static org.mockito.Mockito.*;
+
+/**
+ * Unit tests for {@link DelegatingMapStore}
+ *
+ * @author tkral
+ */
+public class DelegatingMapStoreTest {
+
+    @DataProvider
+    Object[][] checkSingleItemKeyProvider() {
+        return new Object[][] {
+            {
+                new MapStoreKey.Builder()
+                    .setHash("myHashField", "myHashValue")
+                    .build()
+            },
+            {
+                new MapStoreKey.Builder()
+                    .setHash("myHashField", "myHashValue")
+                    .setRange("myRangeField", equalTo("myRangeValue"))
+                    .build()
+            },
+        };
+    }
+
+    @Test(dataProvider = "checkSingleItemKeyProvider")
+    public void testCheckSingleItemKey(final MapStoreKey key) {
+        final DelegatingMapStore delegatingMapStore = new DelegatingMapStore(mock(MapStorePlugin.class));
+
+        catchException(() -> delegatingMapStore.checkSingleItemKey(key));
+        assertThat(caughtException(), is(nullValue()));
+    }
+
+    @DataProvider
+    Object[][] checkSingleItemKeyIllegalProvider() {
+        return new Object[][] {
+            {
+                new MapStoreKey.Builder()
+                    .setHash("myHashField", "myHashValue")
+                    .setRange("myRangeField", all())
+                    .build()
+            },
+            {
+                new MapStoreKey.Builder()
+                    .setHash("myHashField", "myHashValue")
+                    .setRange("myRangeField", greaterThan(1L))
+                    .build()
+            },
+        };
+    }
+
+    @Test(dataProvider = "checkSingleItemKeyIllegalProvider")
+    public void testCheckSingleItemKeyIllegal(final MapStoreKey key) {
+        final DelegatingMapStore delegatingMapStore = new DelegatingMapStore(mock(MapStorePlugin.class));
+        verifyException(() -> delegatingMapStore.checkSingleItemKey(key), IllegalArgumentException.class);
+    }
+
+    @Test
+    public void testCreateTable() {
+        final MapStorePlugin pluginDelegate = mock(MapStorePlugin.class);
+        final MapStore delegatingMapStore = new DelegatingMapStore(pluginDelegate);
+
+        final String tableName = "myTable";
+        final MapStoreTableKey tableKey = new MapStoreTableKey.Builder()
+            .setHash("myHashField", String.class)
+            .build();
+        delegatingMapStore.createTable(tableName, tableKey);
+
+        verify(pluginDelegate).createTable(same(tableName), same(tableKey));
+    }
+
+    @Test
+    public void testDeleteItem() {
+        final MapStorePlugin pluginDelegate = mock(MapStorePlugin.class);
+        final MapStore delegatingMapStore = new DelegatingMapStore(pluginDelegate);
+
+        final String tableName = "myTable";
+        final MapStoreKey tableKey = new MapStoreKey.Builder()
+            .setHash("myHashField", "myHashValue")
+            .setRange("myRangeField", equalTo("myRangeValue"))
+            .build();
+        delegatingMapStore.deleteItem(tableName, tableKey);
+
+        verify(pluginDelegate).deleteItem(same(tableName), same(tableKey));
+    }
+
+    @Test
+    public void testDeleteItemIllegalKey() {
+        final MapStore delegatingMapStore = new DelegatingMapStore(mock(MapStorePlugin.class));
+
+        final String tableName = "myTable";
+        final MapStoreKey tableKey = new MapStoreKey.Builder()
+            .setHash("myHashField", "myHashValue")
+            .setRange("myRangeField", greaterThan(1L))
+            .build();
+        verifyException(() -> delegatingMapStore.deleteItem(tableName, tableKey), IllegalArgumentException.class);
+    }
+
+    @Test
+    public void testDropTable() {
+        final MapStorePlugin pluginDelegate = mock(MapStorePlugin.class);
+        final MapStore delegatingMapStore = new DelegatingMapStore(pluginDelegate);
+
+        final String tableName = "myTable";
+        delegatingMapStore.dropTable(tableName);
+
+        verify(pluginDelegate).dropTable(same(tableName));
+    }
+
+    @Test
+    public void testGetAllItems() {
+        final MapStorePlugin pluginDelegate = mock(MapStorePlugin.class);
+        final MapStore delegatingMapStore = new DelegatingMapStore(pluginDelegate);
+
+        final String tableName = "myTable";
+        delegatingMapStore.getAllItems(tableName);
+
+        verify(pluginDelegate).getAllItems(same(tableName));
+    }
+
+    @Test
+    public void testGetItem() {
+        final MapStorePlugin pluginDelegate = mock(MapStorePlugin.class);
+        final MapStore delegatingMapStore = new DelegatingMapStore(pluginDelegate);
+
+        final String tableName = "myTable";
+        final MapStoreKey tableKey = new MapStoreKey.Builder()
+            .setHash("myHashField", "myHashValue")
+            .setRange("myRangeField", equalTo("myRangeValue"))
+            .build();
+        delegatingMapStore.getItem(tableName, tableKey);
+
+        verify(pluginDelegate).getItem(same(tableName), same(tableKey));
+    }
+
+    @Test
+    public void testGetItemIllegalKey() {
+        final MapStore delegatingMapStore = new DelegatingMapStore(mock(MapStorePlugin.class));
+
+        final String tableName = "myTable";
+        final MapStoreKey tableKey = new MapStoreKey.Builder()
+            .setHash("myHashField", "myHashValue")
+            .setRange("myRangeField", greaterThan(1L))
+            .build();
+        verifyException(() -> delegatingMapStore.getItem(tableName, tableKey), IllegalArgumentException.class);
+    }
+
+    @DataProvider
+    Object[][] getMaxItemProvider() {
+        return new Object[][] {
+            {Collections.emptyList(), Optional.empty()},
+            {Collections.singletonList(Collections.<String, Object>emptyMap()),
+                Optional.of(Collections.<String, Object>emptyMap())},
+        };
+    }
+
+    @Test(dataProvider = "getMaxItemProvider")
+    public void testGetMaxItem(final List<Map<String, Object>> returnedMaxItem,
+                               final Optional<Map<String, Object>> expectedResult) {
+        final MapStorePlugin pluginDelegate = mock(MapStorePlugin.class);
+        when(pluginDelegate.getItems(anyString(), any(MapStoreKey.class), any(MapQueryOptions.class)))
+            .thenReturn(returnedMaxItem);
+        final DelegatingMapStore delegatingMapStore = new DelegatingMapStore(pluginDelegate);
+
+        final String tableName = "myTable";
+        final MapStoreKey tableKey = new MapStoreKey.Builder()
+            .setHash("myHashField", "myHashValue")
+            .setRange("myRangeField", max())
+            .build();
+        final Optional<Map<String, Object>> result = delegatingMapStore.getItem(tableName, tableKey);
+
+        final MapStoreKey expectedMaxItemKey = new MapStoreKey.Builder()
+            .setHash("myHashField", "myHashValue")
+            .setRange("myRangeField", all())
+            .build();
+        final MapQueryOptions expectedQueryOptions = new MapQueryOptions.Builder()
+            .setOrder(Order.DESC).setLimit(1).build();
+        // Verify that we've called get items with the expected parameters
+        verify(pluginDelegate).getItems(same(tableName), eq(expectedMaxItemKey), eq(expectedQueryOptions));
+
+        assertThat(result, is(expectedResult));
+    }
+
+    @DataProvider
+    Object[][] getMinItemProvider() {
+        return new Object[][] {
+            {Collections.emptyList(), Optional.empty()},
+            {Collections.singletonList(Collections.<String, Object>emptyMap()),
+                Optional.of(Collections.<String, Object>emptyMap())},
+        };
+    }
+
+    @Test(dataProvider = "getMinItemProvider")
+    public void testGetMinItem(final List<Map<String, Object>> returnedMinItem,
+                               final Optional<Map<String, Object>> expectedResult) {
+        final MapStorePlugin pluginDelegate = mock(MapStorePlugin.class);
+        when(pluginDelegate.getItems(anyString(), any(MapStoreKey.class), any(MapQueryOptions.class)))
+            .thenReturn(returnedMinItem);
+        final DelegatingMapStore delegatingMapStore = new DelegatingMapStore(pluginDelegate);
+
+        final String tableName = "myTable";
+        final MapStoreKey tableKey = new MapStoreKey.Builder()
+            .setHash("myHashField", "myHashValue")
+            .setRange("myRangeField", min())
+            .build();
+        final Optional<Map<String, Object>> result = delegatingMapStore.getItem(tableName, tableKey);
+
+        final MapStoreKey expectedMaxItemKey = new MapStoreKey.Builder()
+            .setHash("myHashField", "myHashValue")
+            .setRange("myRangeField", all())
+            .build();
+        final MapQueryOptions expectedQueryOptions = new MapQueryOptions.Builder()
+            .setOrder(Order.ASC).setLimit(1).build();
+        // Verify that we've called get items with the expected parameters
+        verify(pluginDelegate).getItems(same(tableName), eq(expectedMaxItemKey), eq(expectedQueryOptions));
+
+        assertThat(result, is(expectedResult));
+    }
+}

--- a/mapstore-core-test/src/test/java/net/spals/appbuilder/mapstore/core/migration/DefaultMapStoreMigrationRunnerTest.java
+++ b/mapstore-core-test/src/test/java/net/spals/appbuilder/mapstore/core/migration/DefaultMapStoreMigrationRunnerTest.java
@@ -1,0 +1,148 @@
+package net.spals.appbuilder.mapstore.core.migration;
+
+import com.google.common.collect.ImmutableMap;
+import net.spals.appbuilder.annotations.migration.AutoBindMigration;
+import net.spals.appbuilder.mapstore.core.MapStore;
+import net.spals.appbuilder.mapstore.core.model.MapStoreKey;
+import net.spals.appbuilder.mapstore.core.model.MapStoreTableKey;
+import org.mockito.Mockito;
+import org.testng.annotations.Test;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.Optional;
+
+import static com.googlecode.catchexception.CatchException.verifyException;
+import static net.spals.appbuilder.mapstore.core.model.SingleValueMapRangeKey.equalTo;
+import static net.spals.appbuilder.mapstore.core.model.ZeroValueMapRangeKey.max;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.same;
+
+/**
+ * Unit tests for {@link DefaultMapStoreMigrationRunner}
+ *
+ * @author tkral
+ */
+public class DefaultMapStoreMigrationRunnerTest {
+
+    @Test
+    public void testCreateMigrationsTable() {
+        final MapStore mapStore = mock(MapStore.class);
+        when(mapStore.createTable(anyString(), any(MapStoreTableKey.class))).thenReturn(true);
+
+        final DefaultMapStoreMigrationRunner migrationRunner =
+            new DefaultMapStoreMigrationRunner("myApplicationName", mapStore, Collections.emptyMap());
+
+        migrationRunner.createMigrationsTable();
+
+        final MapStoreTableKey expectedTableKey = new MapStoreTableKey.Builder()
+            .setHash("applicationName", String.class)
+            .setRange("migrationIndex", Integer.class)
+            .build();
+        verify(mapStore).createTable(eq("migrations"), eq(expectedTableKey));
+    }
+
+    @Test
+    public void testCreateMigrationsTableError() {
+        final MapStore mapStore = mock(MapStore.class);
+        when(mapStore.createTable(anyString(), any(MapStoreTableKey.class))).thenReturn(false);
+
+        final DefaultMapStoreMigrationRunner migrationRunner =
+            new DefaultMapStoreMigrationRunner("myApplicationName", mapStore, Collections.emptyMap());
+
+        verifyException(() -> migrationRunner.createMigrationsTable(), IllegalStateException.class);
+    }
+
+    @Test
+    public void testLookupLastMigrationIndex() {
+        final MapStore mapStore = mock(MapStore.class);
+        final DefaultMapStoreMigrationRunner migrationRunner =
+            new DefaultMapStoreMigrationRunner("myApplicationName", mapStore, Collections.emptyMap());
+
+        final int migrationIndex = migrationRunner.lookupLastMigrationIndex();
+
+        final MapStoreKey expectedKey = new MapStoreKey.Builder()
+            .setHash("applicationName", "myApplicationName")
+            .setRange("migrationIndex", max())
+            .build();
+        verify(mapStore).getItem(eq("migrations"), eq(expectedKey));
+        // We do not provide a return value in the mock so it will return null
+        // and we'd expect that to result in a -1 index
+        assertThat(migrationIndex, is(-1));
+    }
+
+    @Test
+    public void testLookupLastMigrationIndexParse() {
+        final MapStore mapStore = mock(MapStore.class);
+        when(mapStore.getItem(anyString(), any(MapStoreKey.class)))
+            .thenReturn(Optional.of(ImmutableMap.of("applicationName", "myApplicationName",
+                "migrationIndex", 0,
+                "description", "myDesc")));
+
+        final DefaultMapStoreMigrationRunner migrationRunner =
+            new DefaultMapStoreMigrationRunner("myApplicationName", mapStore, Collections.emptyMap());
+
+        final int migrationIndex = migrationRunner.lookupLastMigrationIndex();
+        assertThat(migrationIndex, is(0));
+    }
+
+    @Test
+    public void testRunMigrations() {
+        final MapStore mapStore = mock(MapStore.class);
+        when(mapStore.createTable(anyString(), any(MapStoreTableKey.class))).thenReturn(true);
+        when(mapStore.getItem(anyString(), any(MapStoreKey.class)))
+            .thenReturn(Optional.of(ImmutableMap.of("applicationName", "myApplicationName",
+                "migrationIndex", 0,
+                "description", "myDesc")));
+
+        final MapStoreMigration migration0 = Mockito.spy(new NoopMigration0());
+        final MapStoreMigration migration1 = Mockito.spy(new NoopMigration1());
+        final MapStoreMigration migration2 = Mockito.spy(new NoopMigration2());
+        final Map<Integer, MapStoreMigration> storeMigrations =
+            ImmutableMap.of(0, migration0, 1, migration1, 2, migration2);
+
+        final DefaultMapStoreMigrationRunner migrationRunner =
+            new DefaultMapStoreMigrationRunner("myApplicationName", mapStore, storeMigrations);
+
+        migrationRunner.runMigrations();
+        // Migration 0 is skipped because it has already been run (migrationIndex is 0)
+        verify(migration0, never()).migrate(any(MapStore.class));
+        verify(migration1).migrate(same(mapStore));
+        verify(migration2).migrate(same(mapStore));
+
+        verify(mapStore).putItem(eq("migrations"), eq(expectedMigrationsKey("myApplicationName", 1)),
+            eq(Collections.singletonMap("description", "Migration 1")));
+        verify(mapStore).putItem(eq("migrations"), eq(expectedMigrationsKey("myApplicationName", 2)),
+            eq(Collections.singletonMap("description", "Migration 2")));
+    }
+
+    private MapStoreKey expectedMigrationsKey(final String applicationName, final int index) {
+        return new MapStoreKey.Builder()
+            .setHash("applicationName", applicationName)
+            .setRange("migrationIndex", equalTo(index))
+            .build();
+    }
+
+    @AutoBindMigration(index = 0, description = "Migration 0")
+    private static class NoopMigration0 implements MapStoreMigration {
+        @Override
+        public void migrate(final MapStore mapStore) {  }
+    }
+
+    @AutoBindMigration(index = 1, description = "Migration 1")
+    private static class NoopMigration1 implements MapStoreMigration {
+        @Override
+        public void migrate(final MapStore mapStore) {  }
+    }
+
+    @AutoBindMigration(index = 2, description = "Migration 2")
+    private static class NoopMigration2 implements MapStoreMigration {
+        @Override
+        public void migrate(final MapStore mapStore) {  }
+    }
+}

--- a/mapstore-core/src/main/java/net/spals/appbuilder/mapstore/core/MapStore.java
+++ b/mapstore-core/src/main/java/net/spals/appbuilder/mapstore/core/MapStore.java
@@ -29,7 +29,11 @@ public interface MapStore {
     /**
      * Creates a table with the given key.
      *
-     * @return true iff the creation was successful
+     * Note that this operation is idempotent
+     * so a true response means that the table
+     * exists after execution.
+     *
+     * @return true iff the table exists after execution
      */
     boolean createTable(String tableName, MapStoreTableKey tableKey);
 

--- a/mapstore-dynamodb-test/src/test/scala/net/spals/appbuilder/mapstore/dynamodb/DynamoDBMapStorePluginIT.scala
+++ b/mapstore-dynamodb-test/src/test/scala/net/spals/appbuilder/mapstore/dynamodb/DynamoDBMapStorePluginIT.scala
@@ -64,6 +64,10 @@ class DynamoDBMapStorePluginIT {
     mapStorePlugin.dropTable(rangeTableName)
   }
 
+  @Test def testCreateTableIdempotent() {
+    assertThat(mapStorePlugin.createTable(hashTableName, hashTableKey), is(true))
+  }
+
   @DataProvider def emptyGetProvider(): Array[Array[AnyRef]] = {
     Array(
       // Case: Hash-only key

--- a/mapstore-dynamodb/src/main/scala/net/spals/appbuilder/mapstore/dynamodb/DynamoDBMapStorePlugin.scala
+++ b/mapstore-dynamodb/src/main/scala/net/spals/appbuilder/mapstore/dynamodb/DynamoDBMapStorePlugin.scala
@@ -62,7 +62,14 @@ private[dynamodb] class DynamoDBMapStorePlugin @Inject() (dynamoDBClient: Amazon
     val provisionedThroughput = new ProvisionedThroughput().withReadCapacityUnits(1L).withWriteCapacityUnits(1L)
     createTableRequest.withProvisionedThroughput(provisionedThroughput)
 
-    TableUtils.createTableIfNotExists(dynamoDBClient, createTableRequest)
+    try {
+      TableUtils.createTableIfNotExists(dynamoDBClient, createTableRequest)
+      // If we fall through the create-if-not-exists without error
+      // then the table exists so we'll return true
+      true
+    } catch {
+      case _: RuntimeException => false
+    }
   }
 
   override def dropTable(tableName: String): Boolean = {

--- a/message-core-test/pom.xml
+++ b/message-core-test/pom.xml
@@ -40,4 +40,13 @@
         </dependency>
     </dependencies>
 
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-failsafe-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+
 </project>

--- a/message-core-test/src/test/java/net/spals/appbuilder/message/core/blockingqueue/BlockingQueueMessageIT.java
+++ b/message-core-test/src/test/java/net/spals/appbuilder/message/core/blockingqueue/BlockingQueueMessageIT.java
@@ -56,7 +56,7 @@ public class BlockingQueueMessageIT {
 
     private ExecutorServiceFactory executorServiceFactory() {
         final ExecutorServiceFactory executorServiceFactory = mock(ExecutorServiceFactory.class);
-        when(executorServiceFactory.createFixedThreadPool(anyInt(), any()))
+        when(executorServiceFactory.createFixedThreadPool(anyInt(), any(Class.class)))
                 .thenReturn(Executors.newSingleThreadExecutor());
 
         return executorServiceFactory;


### PR DESCRIPTION
Using the code coverage reports, this is targeting modules and class with more testing to bring the coverage numbers up. This actually drives the number into the yellow at 80%.

Modules tested here include:

1. `executor-core`
2. `mapstore-core`
3. `filestore-core`
4. `message-core`