### PR TITLE
Mock application builder for tests

### DIFF
--- a/app-mock-test/pom.xml
+++ b/app-mock-test/pom.xml
@@ -1,0 +1,43 @@
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+    <parent>
+        <groupId>net.spals.appbuilder</groupId>
+        <artifactId>spals-appbuilder-parent</artifactId>
+        <version>0.2.1-SNAPSHOT</version>
+    </parent>
+
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>net.spals.appbuilder</groupId>
+    <artifactId>spals-appbuilder-app-mock-test</artifactId>
+    <version>0.2.1-SNAPSHOT</version>
+    <packaging>jar</packaging>
+
+    <dependencies>
+        <dependency>
+            <groupId>eu.codearte.catch-exception</groupId>
+            <artifactId>catch-exception</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>eu.codearte.catch-exception</groupId>
+            <artifactId>catch-throwable</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>net.spals.appbuilder</groupId>
+            <artifactId>spals-appbuilder-app-mock</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>java-hamcrest</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.testng</groupId>
+            <artifactId>testng</artifactId>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/app-mock-test/src/test/java/net/spals/appbuilder/app/mock/MockAppTest.java
+++ b/app-mock-test/src/test/java/net/spals/appbuilder/app/mock/MockAppTest.java
@@ -1,0 +1,88 @@
+package net.spals.appbuilder.app.mock;
+
+import com.google.inject.Injector;
+import net.spals.appbuilder.annotations.service.AutoBindSingleton;
+import net.spals.appbuilder.config.service.ServiceScan;
+import org.mockito.internal.util.MockUtil;
+import org.testng.annotations.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.sameInstance;
+import static org.mockito.Mockito.mock;
+
+/**
+ * Unit tests for {@link MockApp}.
+ *
+ * @author tkral
+ */
+public class MockAppTest {
+
+    @Test
+    public void testAddMockitoSingleton() {
+        final AutoBindService mockitoService = mock(AutoBindService.class);
+        final MockApp app = new MockApp.Builder(MockAppTest.class)
+            .addMockSingleton(mockitoService, AutoBindService.class)
+            .build();
+
+        final Injector serviceInjector = app.getServiceInjector();
+        assertThat(serviceInjector.getInstance(AutoBindService.class), sameInstance(mockitoService));
+    }
+
+    @Test
+    public void testAddMockitoOverride() {
+        final MockApp app = new MockApp.Builder(MockAppTest.class)
+            .addMockSingleton(mock(AutoBindService.class), AutoBindService.class)
+            .setServiceScan(new ServiceScan.Builder()
+                .addServicePackages("net.spals.appbuilder.app.mock")
+                .build())
+            .build();
+
+        final Injector serviceInjector = app.getServiceInjector();
+        final AutoBindService service = serviceInjector.getInstance(AutoBindService.class);
+
+        assertThat(MockUtil.isMock(service), is(true));
+    }
+
+    @Test
+    public void testAddManualMockSingleton() {
+        final MockAutoBindService manualMock = new MockAutoBindService();
+        final MockApp app = new MockApp.Builder(MockAppTest.class)
+            .addMockSingleton(manualMock)
+            .build();
+
+        final Injector serviceInjector = app.getServiceInjector();
+        assertThat(serviceInjector.getInstance(AutoBindService.class), sameInstance(manualMock));
+    }
+
+    @Test
+    public void testAddManualMockOverride() {
+        final MockAutoBindService manualMock = new MockAutoBindService();
+        final MockApp app = new MockApp.Builder(MockAppTest.class)
+            .addMockSingleton(manualMock)
+            .setServiceScan(new ServiceScan.Builder()
+                .addServicePackages("net.spals.appbuilder.app.mock")
+                .build())
+            .build();
+
+        final Injector serviceInjector = app.getServiceInjector();
+        final AutoBindService service = serviceInjector.getInstance(AutoBindService.class);
+
+        assertThat(service, sameInstance(manualMock));
+    }
+
+    private interface AutoBindService {  }
+
+    @AutoBindSingleton(baseClass = AutoBindService.class)
+    private static class TestAutoBindService implements AutoBindService {  }
+
+    private static class MockAutoBindService implements AutoBindService, MockSingleton<AutoBindService> {
+
+        @Override
+        public Class<AutoBindService> baseClass() {
+            return AutoBindService.class;
+        }
+    }
+}
+
+

--- a/app-mock/pom.xml
+++ b/app-mock/pom.xml
@@ -1,0 +1,23 @@
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+    <parent>
+        <groupId>net.spals.appbuilder</groupId>
+        <artifactId>spals-appbuilder-parent</artifactId>
+        <version>0.2.1-SNAPSHOT</version>
+    </parent>
+
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>net.spals.appbuilder</groupId>
+    <artifactId>spals-appbuilder-app-mock</artifactId>
+    <version>0.2.1-SNAPSHOT</version>
+    <packaging>jar</packaging>
+
+    <dependencies>
+        <dependency>
+            <groupId>net.spals.appbuilder</groupId>
+            <artifactId>spals-appbuilder-app-core</artifactId>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/app-mock/src/main/java/net/spals/appbuilder/app/mock/MockApp.java
+++ b/app-mock/src/main/java/net/spals/appbuilder/app/mock/MockApp.java
@@ -1,0 +1,114 @@
+package net.spals.appbuilder.app.mock;
+
+import com.google.inject.Module;
+import com.typesafe.config.Config;
+import net.spals.appbuilder.app.core.App;
+import net.spals.appbuilder.app.core.WorkerAppBuilder;
+import net.spals.appbuilder.app.core.generic.GenericWorkerApp;
+import net.spals.appbuilder.config.service.ServiceScan;
+import net.spals.appbuilder.graph.model.ServiceGraphFormat;
+import org.inferred.freebuilder.FreeBuilder;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * An {@link App} implementation that allows a
+ * caller to override scanned services with mocked
+ * services. In other words, this will execute a service scan
+ * and selectively replace services within the dependency
+ * graph with mocked services.
+ * <p/>
+ * This is a valuable pattern as it allows a
+ * mixture of real and mocked services for testing purposes.
+ *
+ * @author tkral
+ */
+@FreeBuilder
+public abstract class MockApp implements App {
+
+    public static class Builder extends MockApp_Builder implements WorkerAppBuilder<MockApp> {
+
+        private final GenericWorkerApp.Builder appDelegateBuilder;
+        private final List<Module> mockSingletonModules = new ArrayList<>();
+
+        public Builder(final Class<?> testClazz) {
+            this.appDelegateBuilder =
+                new GenericWorkerApp.Builder(testClazz.getName(), LoggerFactory.getLogger(testClazz));
+            // Always enable binding overrides so that mocked services
+            // can override real ones.
+            appDelegateBuilder.enableBindingOverrides();
+        }
+
+        public <I> Builder addMockSingleton(final MockSingleton<I> mockSingleton) {
+            final Module mockSingletonModule =
+                binder -> binder.bind(mockSingleton.baseClass()).toInstance((I) mockSingleton);
+            mockSingletonModules.add(mockSingletonModule);
+            return this;
+        }
+
+        public <I, M extends I> Builder addMockSingleton(final M mockedService, final Class<I> baseClass) {
+            final Module mockSingletonModule = binder -> binder.bind(baseClass).toInstance(mockedService);
+            mockSingletonModules.add(mockSingletonModule);
+            return this;
+        }
+
+        @Override
+        public Builder addModule(final Module module) {
+            appDelegateBuilder.addModule(module);
+            return this;
+        }
+
+        @Override
+        public Builder disableErrorOnServiceLeaks() {
+            appDelegateBuilder.disableErrorOnServiceLeaks();
+            return this;
+        }
+
+        @Override
+        public Builder enableBindingOverrides() {
+            // Binding overrides are always enabled
+            return this;
+        }
+
+        @Override
+        public Builder enableServiceGraph(final ServiceGraphFormat graphFormat) {
+            appDelegateBuilder.enableServiceGraph(graphFormat);
+            return this;
+        }
+
+        @Override
+        public Builder setServiceConfig(final Config serviceConfig) {
+            appDelegateBuilder.setServiceConfig(serviceConfig);
+            return this;
+        }
+
+        @Override
+        public Builder setServiceConfigFromClasspath(final String serviceConfigFileName) {
+            appDelegateBuilder.setServiceConfigFromClasspath(serviceConfigFileName);
+            return this;
+        }
+
+        @Override
+        public Builder setServiceScan(final ServiceScan serviceScan) {
+            appDelegateBuilder.setServiceScan(serviceScan);
+            return this;
+        }
+
+        @Override
+        public MockApp build() {
+            // Add all mocked services as the last module so that the
+            // mocks are guaranteed to be added to the dependency graph.
+            mockSingletonModules.forEach(mockSingletonModule -> appDelegateBuilder.addModule(mockSingletonModule));
+
+            final GenericWorkerApp appDelegate = appDelegateBuilder.build();
+            super.setLogger(appDelegate.getLogger());
+            super.setName(appDelegate.getName());
+            super.setServiceConfig(appDelegate.getServiceConfig());
+            super.setServiceInjector(appDelegate.getServiceInjector());
+
+            return super.build();
+        }
+    }
+}

--- a/app-mock/src/main/java/net/spals/appbuilder/app/mock/MockSingleton.java
+++ b/app-mock/src/main/java/net/spals/appbuilder/app/mock/MockSingleton.java
@@ -1,0 +1,23 @@
+package net.spals.appbuilder.app.mock;
+
+import net.spals.appbuilder.annotations.service.AutoBindSingleton;
+
+/**
+ * An interface for mock service singletons that are to be
+ * added to a {@link MockApp}.
+ * <p/>
+ * This emulate the {@link AutoBindSingleton} annotation.
+ * It allows a tester to add binding details to a hand
+ * created a mock service. These details are the same as
+ * what the {@link AutoBindSingleton} annotation provides
+ * at production runtime.
+ *
+ * @author tkral
+ */
+public interface MockSingleton<I> {
+
+    /**
+     * @see {@link AutoBindSingleton#baseClass()}
+     */
+    Class<I> baseClass();
+}

--- a/pom.xml
+++ b/pom.xml
@@ -92,6 +92,7 @@
         <module>app-finatra</module>
         <module>app-finatra-test</module>
         <module>app-mock</module>
+        <module>app-mock-test</module>
         <module>bom</module>
         <module>config</module>
         <module>config-test</module>
@@ -436,6 +437,17 @@
             <dependency>
                 <groupId>net.spals.appbuilder</groupId>
                 <artifactId>spals-appbuilder-model-core-test</artifactId>
+                <version>${project.version}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>net.spals.appbuilder</groupId>
+                <artifactId>spals-appbuilder-app-mock</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>net.spals.appbuilder</groupId>
+                <artifactId>spals-appbuilder-app-mock-test</artifactId>
                 <version>${project.version}</version>
                 <scope>test</scope>
             </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -91,6 +91,7 @@
         <module>app-dropwizard-test</module>
         <module>app-finatra</module>
         <module>app-finatra-test</module>
+        <module>app-mock</module>
         <module>bom</module>
         <module>config</module>
         <module>config-test</module>

--- a/reporting/pom.xml
+++ b/reporting/pom.xml
@@ -24,6 +24,14 @@
         </dependency>
         <dependency>
             <groupId>net.spals.appbuilder</groupId>
+            <artifactId>spals-appbuilder-app-mock</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>net.spals.appbuilder</groupId>
+            <artifactId>spals-appbuilder-app-mock-test</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>net.spals.appbuilder</groupId>
             <artifactId>spals-appbuilder-config</artifactId>
         </dependency>
         <dependency>


### PR DESCRIPTION
@thespags 

Helper for building applications with mocked services which can be used in tests.

Example usage with Mockito:

```java
import net.spals.appbuilder.app.mock.MockApp;

// Create an application with real services, but replace I18NSupport
// service with a mockito mock.
final MockApp app = new MockApp.Builder(MyTest.class)
    .addMockSingleton(mock(I18NSupport.class), I18NSupport.class)
    .setServiceScan(new ServiceScan.Builder().addServicePackages("my.service.package").build())
    .build();

final Injector serviceInjector = app.getServiceInjector();
```

You can also hand craft a mock singleton for injection:

```java
import net.spals.appbuilder.app.mock.MockSingleton;

public class MockI18NSupport implements I18NSupport, MockSingleton<I18NSupport> {

    @Override
    public Class<I18NSupport> baseClass() {
        return I18NSupport.class;
    }
}
```

```java
import net.spals.appbuilder.app.mock.MockApp;

// Create an application with real services, but replace I18NSupport
// service with a hand crafted mock class.
final MockApp app = new MockApp.Builder(MyTest.class)
    .addMockSingleton(new MockI18NSupport())
    .setServiceScan(new ServiceScan.Builder().addServicePackages("my.service.package").build())
    .build();

final Injector serviceInjector = app.getServiceInjector();
```