### PR TITLE
Keystore service

### DIFF
--- a/app-core-test/pom.xml
+++ b/app-core-test/pom.xml
@@ -36,6 +36,10 @@
         </dependency>
         <dependency>
             <groupId>net.spals.appbuilder</groupId>
+            <artifactId>spals-appbuilder-keystore-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>net.spals.appbuilder</groupId>
             <artifactId>spals-appbuilder-mapstore-core</artifactId>
         </dependency>
         <dependency>

--- a/app-core-test/src/test/java/net/spals/appbuilder/app/core/generic/GenericWorkerAppOverridesFTest.java
+++ b/app-core-test/src/test/java/net/spals/appbuilder/app/core/generic/GenericWorkerAppOverridesFTest.java
@@ -48,9 +48,9 @@ public class GenericWorkerAppOverridesFTest {
         final MyCoreSingletonService serviceB = new MyCoreSingletonServiceB();
 
         return new Object[][] {
-                // Ensure that binding order is honored. The last one in is chosen
-                {serviceA, serviceB},
-                {serviceB, serviceA},
+            // Ensure that binding order is honored. The last one in is chosen
+            {serviceA, serviceB},
+            {serviceB, serviceA},
         };
     }
 
@@ -86,7 +86,7 @@ public class GenericWorkerAppOverridesFTest {
         // not the auto-bound service because the custom module came second.
         final Injector serviceInjector = app.getServiceInjector();
         assertThat(serviceInjector.getInstance(MyCoreSingletonService.class),
-                instanceOf(MyCoreSingletonServiceA.class));
+            instanceOf(MyCoreSingletonServiceA.class));
     }
 
     @Test
@@ -115,17 +115,17 @@ public class GenericWorkerAppOverridesFTest {
 
         final GenericWorkerApp app = new GenericWorkerApp.Builder(
                 "testEnableBindingOverrides", LOGGER)
-                .addModule(binder -> binder.bind(MyCoreSingletonService.class)
-                        .toInstance(new MyCoreSingletonServiceA()))
-                .setServiceScan(serviceScan)
-                .enableBindingOverrides()
-                .build();
+            .addModule(binder -> binder.bind(MyCoreSingletonService.class)
+                .toInstance(new MyCoreSingletonServiceA()))
+            .setServiceScan(serviceScan)
+            .enableBindingOverrides()
+            .build();
 
         // Assert that the binding override uses the auto-bound service,
         // not the custom module service because the auto-binding came second.
         final Injector serviceInjector = app.getServiceInjector();
         assertThat(serviceInjector.getInstance(MyCoreSingletonService.class),
-                instanceOf(MyCoreSingleTonServiceAutoBind.class));
+            instanceOf(MyCoreSingleTonServiceAutoBind.class));
     }
 
     private ServiceScan createServiceScan() {

--- a/app-core-test/src/test/java/net/spals/appbuilder/app/core/generic/MinimalGenericWorkerAppFTest.java
+++ b/app-core-test/src/test/java/net/spals/appbuilder/app/core/generic/MinimalGenericWorkerAppFTest.java
@@ -44,8 +44,8 @@ public class MinimalGenericWorkerAppFTest {
     @DataProvider
     Object[][] noDefaultServiceInjectionProvider() {
         return new Object[][] {
-                {TypeLiteral.get(ExecutorServiceFactory.class)},
-                {TypeLiteral.get(Tracer.class)},
+            {TypeLiteral.get(ExecutorServiceFactory.class)},
+            {TypeLiteral.get(Tracer.class)},
         };
     }
 

--- a/app-core-test/src/test/java/net/spals/appbuilder/app/core/jaxrs/MinimalJaxRsWebAppFTest.java
+++ b/app-core-test/src/test/java/net/spals/appbuilder/app/core/jaxrs/MinimalJaxRsWebAppFTest.java
@@ -37,9 +37,9 @@ public class MinimalJaxRsWebAppFTest {
     private final BiFunction<String, Filter, FilterRegistration.Dynamic> filterRegistration = mock(BiFunction.class);
 
     private final JaxRsWebApp minimalApp = new JaxRsWebApp.Builder("minimal", LOGGER)
-            .setConfigurable(configurable)
-            .setFilterRegistration(filterRegistration)
-            .build();
+        .setConfigurable(configurable)
+        .setFilterRegistration(filterRegistration)
+        .build();
 
     @Test
     public void testJaxRsWebAppLogger() {
@@ -59,8 +59,8 @@ public class MinimalJaxRsWebAppFTest {
     @DataProvider
     Object[][] noDefaultServiceInjectionProvider() {
         return new Object[][] {
-                {TypeLiteral.get(ExecutorServiceFactory.class)},
-                {TypeLiteral.get(Tracer.class)},
+            {TypeLiteral.get(ExecutorServiceFactory.class)},
+            {TypeLiteral.get(Tracer.class)},
         };
     }
 

--- a/app-core-test/src/test/java/net/spals/appbuilder/app/core/jaxrs/SampleJaxRsWebAppFTest.java
+++ b/app-core-test/src/test/java/net/spals/appbuilder/app/core/jaxrs/SampleJaxRsWebAppFTest.java
@@ -19,6 +19,8 @@ import net.spals.appbuilder.executor.core.ExecutorServiceFactory;
 import net.spals.appbuilder.filestore.core.FileStore;
 import net.spals.appbuilder.filestore.core.FileStorePlugin;
 import net.spals.appbuilder.graph.model.ServiceGraphFormat;
+import net.spals.appbuilder.keystore.core.KeyStore;
+import net.spals.appbuilder.keystore.core.KeyStorePlugin;
 import net.spals.appbuilder.mapstore.core.MapStore;
 import net.spals.appbuilder.mapstore.core.MapStorePlugin;
 import net.spals.appbuilder.message.core.MessageConsumer;
@@ -65,32 +67,37 @@ public class SampleJaxRsWebAppFTest {
     };
 
     private final JaxRsWebApp sampleApp = new JaxRsWebApp.Builder("sample", LOGGER)
-            .setConfigurable(configurable)
-            .enableServiceGraph(ServiceGraphFormat.ASCII)
-            .setFilterRegistration(filterRegistration)
-            .setServiceConfigFromClasspath("config/sample-jaxrs-service.conf")
-            .setServiceScan(new ServiceScan.Builder()
-                    .addServicePackages("net.spals.appbuilder.app.core.sample")
-                    .addDefaultServices(FileStore.class)
-                    .addDefaultServices(MapStore.class)
-                    .addDefaultServices(MessageConsumer.class, MessageProducer.class)
-                    .addDefaultServices(ModelSerializer.class)
-                    .build())
-            .addBootstrapModule(new SampleCoreBootstrapModule())
-            .addModule(new SampleCoreGuiceModule())
-            .enableRequestScoping()
-            .build();
+        .setConfigurable(configurable)
+        .enableServiceGraph(ServiceGraphFormat.ASCII)
+        .setFilterRegistration(filterRegistration)
+        .setServiceConfigFromClasspath("config/sample-jaxrs-service.conf")
+        .setServiceScan(new ServiceScan.Builder()
+            .addServicePackages("net.spals.appbuilder.app.core.sample")
+            .addDefaultServices(FileStore.class)
+            .addDefaultServices(KeyStore.class)
+            .addDefaultServices(MapStore.class)
+            .addDefaultServices(MessageConsumer.class, MessageProducer.class)
+            .addDefaultServices(ModelSerializer.class)
+            .build())
+        .addBootstrapModule(new SampleCoreBootstrapModule())
+        .addModule(new SampleCoreGuiceModule())
+        .enableRequestScoping()
+        .build();
 
     @DataProvider
     Object[][] serviceConfigProvider() {
         return new Object[][] {
-                {"fileStore.system", "localFS"},
-                {"mapStore.system", "mapDB"},
+            {"fileStore.system", "localFS"},
+            {"keyStore.system", "password"},
+            {"mapStore.system", "mapDB"},
         };
     }
 
     @Test(dataProvider = "serviceConfigProvider")
-    public void testServiceConfig(final String configKey, final Object expectedConfigValue) {
+    public void testServiceConfig(
+        final String configKey,
+        final Object expectedConfigValue
+    ) {
         final Config serviceConfig = sampleApp.getServiceConfig();
         assertThat(serviceConfig.getAnyRef(configKey), is(expectedConfigValue));
     }
@@ -98,17 +105,20 @@ public class SampleJaxRsWebAppFTest {
     @DataProvider
     Object[][] customModuleInjectionProvider() {
         return new Object[][] {
-                {"AutoBoundModule", "sample:SampleCoreAutoBoundModule"},
-                {"BootstrapModule", "SampleCoreBootstrapModule"},
-                {"GuiceModule", "SampleCoreGuiceModule"},
+            {"AutoBoundModule", "sample:SampleCoreAutoBoundModule"},
+            {"BootstrapModule", "SampleCoreBootstrapModule"},
+            {"GuiceModule", "SampleCoreGuiceModule"},
         };
     }
 
     @Test(dataProvider = "customModuleInjectionProvider")
-    public void testCustomModuleInjection(final String keyName, final String expectedBindValue) {
+    public void testCustomModuleInjection(
+        final String keyName,
+        final String expectedBindValue
+    ) {
         final Injector serviceInjector = sampleApp.getServiceInjector();
         assertThat(serviceInjector.getInstance(Key.get(String.class, Names.named(keyName))),
-                is(expectedBindValue));
+            is(expectedBindValue));
     }
 
     @Test
@@ -129,11 +139,24 @@ public class SampleJaxRsWebAppFTest {
         assertThat(serviceInjector.getInstance(FileStore.class), notNullValue());
 
         final TypeLiteral<Map<String, FileStorePlugin>> fileStorePluginMapKey =
-                new TypeLiteral<Map<String, FileStorePlugin>>(){};
+            new TypeLiteral<Map<String, FileStorePlugin>>(){};
         final Map<String, FileStorePlugin> fileStorePluginMap =
-                serviceInjector.getInstance(Key.get(fileStorePluginMapKey));
+            serviceInjector.getInstance(Key.get(fileStorePluginMapKey));
         assertThat(fileStorePluginMap, aMapWithSize(1));
         assertThat(fileStorePluginMap, hasKey("localFS"));
+    }
+
+    @Test
+    public void testKeyStoreInjection() {
+        final Injector serviceInjector = sampleApp.getServiceInjector();
+        assertThat(serviceInjector.getInstance(KeyStore.class), notNullValue());
+
+        final TypeLiteral<Map<String, KeyStorePlugin>> keyStorePluginMapKey =
+            new TypeLiteral<Map<String, KeyStorePlugin>>(){};
+        final Map<String, KeyStorePlugin> keyStorePluginMap =
+            serviceInjector.getInstance(Key.get(keyStorePluginMapKey));
+        assertThat(keyStorePluginMap, aMapWithSize(1));
+        assertThat(keyStorePluginMap, hasKey("password"));
     }
 
     @Test
@@ -142,9 +165,9 @@ public class SampleJaxRsWebAppFTest {
         assertThat(serviceInjector.getInstance(MapStore.class), notNullValue());
 
         final TypeLiteral<Map<String, MapStorePlugin>> mapStorePluginMapKey =
-                new TypeLiteral<Map<String, MapStorePlugin>>(){};
+            new TypeLiteral<Map<String, MapStorePlugin>>(){};
         final Map<String, MapStorePlugin> mapStorePluginMap =
-                serviceInjector.getInstance(Key.get(mapStorePluginMapKey));
+            serviceInjector.getInstance(Key.get(mapStorePluginMapKey));
         assertThat(mapStorePluginMap, aMapWithSize(1));
         assertThat(mapStorePluginMap, hasKey("mapDB"));
     }
@@ -155,9 +178,9 @@ public class SampleJaxRsWebAppFTest {
         assertThat(serviceInjector.getInstance(MessageConsumer.class), notNullValue());
 
         final TypeLiteral<Map<String, MessageConsumerPlugin>> messageConsumerPluginMapKey =
-                new TypeLiteral<Map<String, MessageConsumerPlugin>>(){};
+            new TypeLiteral<Map<String, MessageConsumerPlugin>>(){};
         final Map<String, MessageConsumerPlugin> messageConsumerPluginMap =
-                serviceInjector.getInstance(Key.get(messageConsumerPluginMapKey));
+            serviceInjector.getInstance(Key.get(messageConsumerPluginMapKey));
         assertThat(messageConsumerPluginMap, aMapWithSize(1));
         assertThat(messageConsumerPluginMap, hasKey("blockingQueue"));
     }
@@ -167,9 +190,9 @@ public class SampleJaxRsWebAppFTest {
         final Injector serviceInjector = sampleApp.getServiceInjector();
 
         final TypeLiteral<Set<MessageConsumerCallback<?>>> messageCallbackSetKey =
-                new TypeLiteral<Set<MessageConsumerCallback<?>>>(){};
+            new TypeLiteral<Set<MessageConsumerCallback<?>>>(){};
         final Set<MessageConsumerCallback<?>> messageCallbackSet =
-                serviceInjector.getInstance(Key.get(messageCallbackSetKey));
+            serviceInjector.getInstance(Key.get(messageCallbackSetKey));
         assertThat(messageCallbackSet, notNullValue());
     }
 
@@ -179,9 +202,9 @@ public class SampleJaxRsWebAppFTest {
         assertThat(serviceInjector.getInstance(MessageProducer.class), notNullValue());
 
         final TypeLiteral<Map<String, MessageProducerPlugin>> messageProducerPluginMapKey =
-                new TypeLiteral<Map<String, MessageProducerPlugin>>(){};
+            new TypeLiteral<Map<String, MessageProducerPlugin>>(){};
         final Map<String, MessageProducerPlugin> messageProducerPluginMap =
-                serviceInjector.getInstance(Key.get(messageProducerPluginMapKey));
+            serviceInjector.getInstance(Key.get(messageProducerPluginMapKey));
         assertThat(messageProducerPluginMap, aMapWithSize(1));
         assertThat(messageProducerPluginMap, hasKey("blockingQueue"));
     }
@@ -191,9 +214,9 @@ public class SampleJaxRsWebAppFTest {
         final Injector serviceInjector = sampleApp.getServiceInjector();
 
         final TypeLiteral<Map<String, ModelSerializer>> modelSerializerMapKey =
-                new TypeLiteral<Map<String, ModelSerializer>>(){};
+            new TypeLiteral<Map<String, ModelSerializer>>(){};
         final Map<String, ModelSerializer> modelSerializerMap =
-                serviceInjector.getInstance(Key.get(modelSerializerMapKey));
+            serviceInjector.getInstance(Key.get(modelSerializerMapKey));
         assertThat(modelSerializerMap, aMapWithSize(1));
         assertThat(modelSerializerMap, hasKey("pojo"));
     }
@@ -217,12 +240,12 @@ public class SampleJaxRsWebAppFTest {
     @DataProvider
     Object[][] webInjectionProvider() {
         return new Object[][] {
-                {SampleCoreDynamicFeature.class},
-                {SampleCoreExceptionMapper.class},
-                {SampleCoreProvider.class},
-                {SampleCoreRequestFilter.class},
-                {SampleCoreResource.class},
-                {SampleCoreResponseFilter.class},
+            {SampleCoreDynamicFeature.class},
+            {SampleCoreExceptionMapper.class},
+            {SampleCoreProvider.class},
+            {SampleCoreRequestFilter.class},
+            {SampleCoreResource.class},
+            {SampleCoreResponseFilter.class},
         };
     }
 

--- a/app-core-test/src/test/resources/config/sample-generic-service.conf
+++ b/app-core-test/src/test/resources/config/sample-generic-service.conf
@@ -6,6 +6,11 @@ fileStore.system="localFS"
 fileStore.localFS.basePath=${HOME}"/.localFS"
 fileStore.localFS.basePath=${?LOCALFS_BASE_PATH}
 
+### KeyStore configuration ###
+keyStore.system="password"
+
+keyStore.password.pwd="myPassword"
+
 ### MapStore configuration ###
 mapStore.system="mapDB"
 

--- a/app-core-test/src/test/resources/config/sample-jaxrs-service.conf
+++ b/app-core-test/src/test/resources/config/sample-jaxrs-service.conf
@@ -6,6 +6,11 @@ fileStore.system="localFS"
 fileStore.localFS.basePath=${HOME}"/.localFS"
 fileStore.localFS.basePath=${?LOCALFS_BASE_PATH}
 
+### KeyStore configuration ###
+keyStore.system="password"
+
+keyStore.password.pwd="myPassword"
+
 ### MapStore configuration ###
 mapStore.system="mapDB"
 

--- a/app-dropwizard-test/pom.xml
+++ b/app-dropwizard-test/pom.xml
@@ -72,6 +72,10 @@
         </dependency>
         <dependency>
             <groupId>net.spals.appbuilder.plugins</groupId>
+            <artifactId>spals-appbuilder-mapstore-mongodb</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>net.spals.appbuilder.plugins</groupId>
             <artifactId>spals-appbuilder-message-kafka</artifactId>
         </dependency>
         <dependency>

--- a/app-dropwizard-test/pom.xml
+++ b/app-dropwizard-test/pom.xml
@@ -40,6 +40,10 @@
         </dependency>
         <dependency>
             <groupId>net.spals.appbuilder</groupId>
+            <artifactId>spals-appbuilder-keystore-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>net.spals.appbuilder</groupId>
             <artifactId>spals-appbuilder-mapstore-core</artifactId>
         </dependency>
         <dependency>

--- a/app-dropwizard-test/src/test/java/net/spals/appbuilder/app/dropwizard/MinimalDropwizardWebAppFTest.java
+++ b/app-dropwizard-test/src/test/java/net/spals/appbuilder/app/dropwizard/MinimalDropwizardWebAppFTest.java
@@ -32,7 +32,7 @@ import static org.hamcrest.Matchers.notNullValue;
 public class MinimalDropwizardWebAppFTest {
 
     private final DropwizardTestSupport<Configuration> testServerWrapper =
-            new DropwizardTestSupport<>(MinimalDropwizardWebApp.class, new Configuration());
+        new DropwizardTestSupport<>(MinimalDropwizardWebApp.class, new Configuration());
     private DropwizardWebApp webAppDelegate;
 
     @BeforeClass
@@ -59,10 +59,10 @@ public class MinimalDropwizardWebAppFTest {
     @DataProvider
     Object[][] defaultServiceInjectionProvider() {
         return new Object[][] {
-                {TypeLiteral.get(Environment.class)},
-                {TypeLiteral.get(HealthCheckRegistry.class)},
-                {TypeLiteral.get(MetricRegistry.class)},
-                {TypeLiteral.get(Validator.class)},
+            {TypeLiteral.get(Environment.class)},
+            {TypeLiteral.get(HealthCheckRegistry.class)},
+            {TypeLiteral.get(MetricRegistry.class)},
+            {TypeLiteral.get(Validator.class)},
         } ;
     }
 
@@ -75,8 +75,8 @@ public class MinimalDropwizardWebAppFTest {
     @DataProvider
     Object[][] noDefaultServiceInjectionProvider() {
         return new Object[][] {
-                {TypeLiteral.get(ExecutorServiceFactory.class)},
-                {TypeLiteral.get(Tracer.class)},
+            {TypeLiteral.get(ExecutorServiceFactory.class)},
+            {TypeLiteral.get(Tracer.class)},
         };
     }
 

--- a/app-dropwizard-test/src/test/java/net/spals/appbuilder/app/dropwizard/PluginsDropwizardWebAppFTest.java
+++ b/app-dropwizard-test/src/test/java/net/spals/appbuilder/app/dropwizard/PluginsDropwizardWebAppFTest.java
@@ -12,6 +12,8 @@ import io.opentracing.Tracer;
 import net.spals.appbuilder.app.dropwizard.plugins.PluginsDropwizardWebApp;
 import net.spals.appbuilder.filestore.core.FileStore;
 import net.spals.appbuilder.filestore.core.FileStorePlugin;
+import net.spals.appbuilder.keystore.core.KeyStore;
+import net.spals.appbuilder.keystore.core.KeyStorePlugin;
 import net.spals.appbuilder.mapstore.core.MapStore;
 import net.spals.appbuilder.mapstore.core.MapStorePlugin;
 import net.spals.appbuilder.message.core.MessageConsumer;
@@ -38,7 +40,7 @@ import static org.hamcrest.Matchers.*;
 public class PluginsDropwizardWebAppFTest {
 
     private final DropwizardTestSupport<Configuration> testServerWrapper =
-            new DropwizardTestSupport<>(PluginsDropwizardWebApp.class, PluginsDropwizardWebApp.APP_CONFIG_FILE_NAME);
+        new DropwizardTestSupport<>(PluginsDropwizardWebApp.class, PluginsDropwizardWebApp.APP_CONFIG_FILE_NAME);
     private DropwizardWebApp webAppDelegate;
 
     @BeforeClass
@@ -58,12 +60,25 @@ public class PluginsDropwizardWebAppFTest {
         assertThat(serviceInjector.getInstance(FileStore.class), notNullValue());
 
         final TypeLiteral<Map<String, FileStorePlugin>> fileStorePluginMapKey =
-                new TypeLiteral<Map<String, FileStorePlugin>>(){};
+            new TypeLiteral<Map<String, FileStorePlugin>>(){};
         final Map<String, FileStorePlugin> fileStorePluginMap =
-                serviceInjector.getInstance(Key.get(fileStorePluginMapKey));
+            serviceInjector.getInstance(Key.get(fileStorePluginMapKey));
         assertThat(fileStorePluginMap, aMapWithSize(2));
         assertThat(fileStorePluginMap, hasKey("localFS"));
         assertThat(fileStorePluginMap, hasKey("s3"));
+    }
+
+    @Test
+    public void testKeyStoreInjection() {
+        final Injector serviceInjector = webAppDelegate.getServiceInjector();
+        assertThat(serviceInjector.getInstance(KeyStore.class), notNullValue());
+
+        final TypeLiteral<Map<String, KeyStorePlugin>> keyStorePluginMapKey =
+            new TypeLiteral<Map<String, KeyStorePlugin>>(){};
+        final Map<String, KeyStorePlugin> keyStorePluginMap =
+            serviceInjector.getInstance(Key.get(keyStorePluginMapKey));
+        assertThat(keyStorePluginMap, aMapWithSize(1));
+        assertThat(keyStorePluginMap, hasKey("password"));
     }
 
     @Test
@@ -72,9 +87,9 @@ public class PluginsDropwizardWebAppFTest {
         assertThat(serviceInjector.getInstance(MapStore.class), notNullValue());
 
         final TypeLiteral<Map<String, MapStorePlugin>> mapStorePluginMapKey =
-                new TypeLiteral<Map<String, MapStorePlugin>>(){};
+            new TypeLiteral<Map<String, MapStorePlugin>>(){};
         final Map<String, MapStorePlugin> mapStorePluginMap =
-                serviceInjector.getInstance(Key.get(mapStorePluginMapKey));
+            serviceInjector.getInstance(Key.get(mapStorePluginMapKey));
         assertThat(mapStorePluginMap, aMapWithSize(3));
         assertThat(mapStorePluginMap, hasKey("cassandra"));
         assertThat(mapStorePluginMap, hasKey("dynamoDB"));
@@ -99,9 +114,9 @@ public class PluginsDropwizardWebAppFTest {
         assertThat(serviceInjector.getInstance(MessageConsumer.class), notNullValue());
 
         final TypeLiteral<Map<String, MessageConsumerPlugin>> messageConsumerPluginMapKey =
-                new TypeLiteral<Map<String, MessageConsumerPlugin>>(){};
+            new TypeLiteral<Map<String, MessageConsumerPlugin>>(){};
         final Map<String, MessageConsumerPlugin> messageConsumerPluginMap =
-                serviceInjector.getInstance(Key.get(messageConsumerPluginMapKey));
+            serviceInjector.getInstance(Key.get(messageConsumerPluginMapKey));
         assertThat(messageConsumerPluginMap, aMapWithSize(3));
         assertThat(messageConsumerPluginMap, hasKey("blockingQueue"));
         assertThat(messageConsumerPluginMap, hasKey("kafka"));
@@ -114,9 +129,9 @@ public class PluginsDropwizardWebAppFTest {
         assertThat(serviceInjector.getInstance(MessageProducer.class), notNullValue());
 
         final TypeLiteral<Map<String, MessageProducerPlugin>> messageProducerPluginMapKey =
-                new TypeLiteral<Map<String, MessageProducerPlugin>>(){};
+            new TypeLiteral<Map<String, MessageProducerPlugin>>(){};
         final Map<String, MessageProducerPlugin> messageProducerPluginMap =
-                serviceInjector.getInstance(Key.get(messageProducerPluginMapKey));
+            serviceInjector.getInstance(Key.get(messageProducerPluginMapKey));
         assertThat(messageProducerPluginMap, aMapWithSize(3));
         assertThat(messageProducerPluginMap, hasKey("blockingQueue"));
         assertThat(messageProducerPluginMap, hasKey("kafka"));
@@ -128,9 +143,9 @@ public class PluginsDropwizardWebAppFTest {
         final Injector serviceInjector = webAppDelegate.getServiceInjector();
 
         final TypeLiteral<Map<String, ModelSerializer>> modelSerializerMapKey =
-                new TypeLiteral<Map<String, ModelSerializer>>(){};
+            new TypeLiteral<Map<String, ModelSerializer>>(){};
         final Map<String, ModelSerializer> modelSerializerMap =
-                serviceInjector.getInstance(Key.get(modelSerializerMapKey));
+            serviceInjector.getInstance(Key.get(modelSerializerMapKey));
         assertThat(modelSerializerMap, aMapWithSize(2));
         assertThat(modelSerializerMap, hasKey("pojo"));
         assertThat(modelSerializerMap, hasKey("protobuf"));
@@ -142,9 +157,9 @@ public class PluginsDropwizardWebAppFTest {
         assertThat(serviceInjector.getInstance(Tracer.class), instanceOf(NoopTracer.class));
 
         final TypeLiteral<Map<String, TracerPlugin>> tracerPluginMapKey =
-                new TypeLiteral<Map<String, TracerPlugin>>(){};
+            new TypeLiteral<Map<String, TracerPlugin>>(){};
         final Map<String, TracerPlugin> tracerPluginMap =
-                serviceInjector.getInstance(Key.get(tracerPluginMapKey));
+            serviceInjector.getInstance(Key.get(tracerPluginMapKey));
         assertThat(tracerPluginMap, aMapWithSize(2));
         assertThat(tracerPluginMap, hasKey("lightstep"));
         assertThat(tracerPluginMap, hasKey("noop"));
@@ -155,9 +170,9 @@ public class PluginsDropwizardWebAppFTest {
         final Injector serviceInjector = webAppDelegate.getServiceInjector();
 
         final TypeLiteral<Map<String, TracerTag>> tracerTagMapKey =
-                new TypeLiteral<Map<String, TracerTag>>(){};
+            new TypeLiteral<Map<String, TracerTag>>(){};
         final Map<String, TracerTag> tracerTagMap =
-                serviceInjector.getInstance(Key.get(tracerTagMapKey));
+            serviceInjector.getInstance(Key.get(tracerTagMapKey));
         assertThat(tracerTagMap, aMapWithSize(2));
         assertThat(tracerTagMap, hasEntry(is("key1"),
             is(new TracerTag.Builder().setTag("key1").setValue("value").build())));

--- a/app-dropwizard-test/src/test/java/net/spals/appbuilder/app/dropwizard/PluginsDropwizardWebAppFTest.java
+++ b/app-dropwizard-test/src/test/java/net/spals/appbuilder/app/dropwizard/PluginsDropwizardWebAppFTest.java
@@ -90,10 +90,11 @@ public class PluginsDropwizardWebAppFTest {
             new TypeLiteral<Map<String, MapStorePlugin>>(){};
         final Map<String, MapStorePlugin> mapStorePluginMap =
             serviceInjector.getInstance(Key.get(mapStorePluginMapKey));
-        assertThat(mapStorePluginMap, aMapWithSize(3));
+        assertThat(mapStorePluginMap, aMapWithSize(4));
         assertThat(mapStorePluginMap, hasKey("cassandra"));
         assertThat(mapStorePluginMap, hasKey("dynamoDB"));
         assertThat(mapStorePluginMap, hasKey("mapDB"));
+        assertThat(mapStorePluginMap, hasKey("mongoDB"));
     }
 
     @Test

--- a/app-dropwizard-test/src/test/java/net/spals/appbuilder/app/dropwizard/SampleDropwizardWebAppFTest.java
+++ b/app-dropwizard-test/src/test/java/net/spals/appbuilder/app/dropwizard/SampleDropwizardWebAppFTest.java
@@ -14,6 +14,8 @@ import net.spals.appbuilder.app.dropwizard.sample.SampleDropwizardWebApp;
 import net.spals.appbuilder.executor.core.ExecutorServiceFactory;
 import net.spals.appbuilder.filestore.core.FileStore;
 import net.spals.appbuilder.filestore.core.FileStorePlugin;
+import net.spals.appbuilder.keystore.core.KeyStore;
+import net.spals.appbuilder.keystore.core.KeyStorePlugin;
 import net.spals.appbuilder.mapstore.core.MapStore;
 import net.spals.appbuilder.mapstore.core.MapStorePlugin;
 import net.spals.appbuilder.message.core.MessageConsumer;
@@ -41,7 +43,7 @@ import static org.hamcrest.Matchers.*;
 public class SampleDropwizardWebAppFTest {
 
     private final DropwizardTestSupport<Configuration> testServerWrapper =
-            new DropwizardTestSupport<>(SampleDropwizardWebApp.class, SampleDropwizardWebApp.APP_CONFIG_FILE_NAME);
+        new DropwizardTestSupport<>(SampleDropwizardWebApp.class, SampleDropwizardWebApp.APP_CONFIG_FILE_NAME);
     private DropwizardWebApp webAppDelegate;
 
     @BeforeClass
@@ -58,13 +60,17 @@ public class SampleDropwizardWebAppFTest {
     @DataProvider
     Object[][] serviceConfigProvider() {
         return new Object[][] {
-                {"fileStore.system", "localFS"},
-                {"mapStore.system", "mapDB"},
+            {"fileStore.system", "localFS"},
+            {"keyStore.system", "password"},
+            {"mapStore.system", "mapDB"},
         };
     }
 
     @Test(dataProvider = "serviceConfigProvider")
-    public void testServiceConfig(final String configKey, final Object expectedConfigValue) {
+    public void testServiceConfig(
+        final String configKey,
+        final Object expectedConfigValue
+    ) {
         final Config serviceConfig = webAppDelegate.getServiceConfig();
         assertThat(serviceConfig.getAnyRef(configKey), is(expectedConfigValue));
     }
@@ -72,17 +78,20 @@ public class SampleDropwizardWebAppFTest {
     @DataProvider
     Object[][] customModuleInjectionProvider() {
         return new Object[][] {
-                {"AutoBoundModule", "SampleDropwizardWebApp:SampleDropwizardAutoBoundModule"},
-                {"BootstrapModule", "SampleDropwizardBootstrapModule"},
-                {"GuiceModule", "SampleDropwizardGuiceModule"},
+            {"AutoBoundModule", "SampleDropwizardWebApp:SampleDropwizardAutoBoundModule"},
+            {"BootstrapModule", "SampleDropwizardBootstrapModule"},
+            {"GuiceModule", "SampleDropwizardGuiceModule"},
         };
     }
 
     @Test(dataProvider = "customModuleInjectionProvider")
-    public void testCustomModuleInjection(final String keyName, final String expectedBindValue) {
+    public void testCustomModuleInjection(
+        final String keyName,
+        final String expectedBindValue
+    ) {
         final Injector serviceInjector = webAppDelegate.getServiceInjector();
         assertThat(serviceInjector.getInstance(Key.get(String.class, Names.named(keyName))),
-                is(expectedBindValue));
+            is(expectedBindValue));
     }
 
     @Test
@@ -103,11 +112,24 @@ public class SampleDropwizardWebAppFTest {
         assertThat(serviceInjector.getInstance(FileStore.class), notNullValue());
 
         final TypeLiteral<Map<String, FileStorePlugin>> fileStorePluginMapKey =
-                new TypeLiteral<Map<String, FileStorePlugin>>(){};
+            new TypeLiteral<Map<String, FileStorePlugin>>(){};
         final Map<String, FileStorePlugin> fileStorePluginMap =
-                serviceInjector.getInstance(Key.get(fileStorePluginMapKey));
+            serviceInjector.getInstance(Key.get(fileStorePluginMapKey));
         assertThat(fileStorePluginMap, aMapWithSize(1));
         assertThat(fileStorePluginMap, hasKey("localFS"));
+    }
+
+    @Test
+    public void testKeyStoreInjection() {
+        final Injector serviceInjector = webAppDelegate.getServiceInjector();
+        assertThat(serviceInjector.getInstance(KeyStore.class), notNullValue());
+
+        final TypeLiteral<Map<String, KeyStorePlugin>> keyStorePluginMapKey =
+            new TypeLiteral<Map<String, KeyStorePlugin>>(){};
+        final Map<String, KeyStorePlugin> keyStorePluginMap =
+            serviceInjector.getInstance(Key.get(keyStorePluginMapKey));
+        assertThat(keyStorePluginMap, aMapWithSize(1));
+        assertThat(keyStorePluginMap, hasKey("password"));
     }
 
     @Test
@@ -116,9 +138,9 @@ public class SampleDropwizardWebAppFTest {
         assertThat(serviceInjector.getInstance(MapStore.class), notNullValue());
 
         final TypeLiteral<Map<String, MapStorePlugin>> mapStorePluginMapKey =
-                new TypeLiteral<Map<String, MapStorePlugin>>(){};
+            new TypeLiteral<Map<String, MapStorePlugin>>(){};
         final Map<String, MapStorePlugin> mapStorePluginMap =
-                serviceInjector.getInstance(Key.get(mapStorePluginMapKey));
+            serviceInjector.getInstance(Key.get(mapStorePluginMapKey));
         assertThat(mapStorePluginMap, aMapWithSize(1));
         assertThat(mapStorePluginMap, hasKey("mapDB"));
     }
@@ -129,9 +151,9 @@ public class SampleDropwizardWebAppFTest {
         assertThat(serviceInjector.getInstance(MessageConsumer.class), notNullValue());
 
         final TypeLiteral<Map<String, MessageConsumerPlugin>> messageConsumerPluginMapKey =
-                new TypeLiteral<Map<String, MessageConsumerPlugin>>(){};
+            new TypeLiteral<Map<String, MessageConsumerPlugin>>(){};
         final Map<String, MessageConsumerPlugin> messageConsumerPluginMap =
-                serviceInjector.getInstance(Key.get(messageConsumerPluginMapKey));
+            serviceInjector.getInstance(Key.get(messageConsumerPluginMapKey));
         assertThat(messageConsumerPluginMap, aMapWithSize(1));
         assertThat(messageConsumerPluginMap, hasKey("blockingQueue"));
     }
@@ -141,9 +163,9 @@ public class SampleDropwizardWebAppFTest {
         final Injector serviceInjector = webAppDelegate.getServiceInjector();
 
         final TypeLiteral<Set<MessageConsumerCallback<?>>> messageCallbackSetKey =
-                new TypeLiteral<Set<MessageConsumerCallback<?>>>(){};
+            new TypeLiteral<Set<MessageConsumerCallback<?>>>(){};
         final Set<MessageConsumerCallback<?>> messageCallbackSet =
-                serviceInjector.getInstance(Key.get(messageCallbackSetKey));
+            serviceInjector.getInstance(Key.get(messageCallbackSetKey));
         assertThat(messageCallbackSet, notNullValue());
     }
 
@@ -153,9 +175,9 @@ public class SampleDropwizardWebAppFTest {
         assertThat(serviceInjector.getInstance(MessageProducer.class), notNullValue());
 
         final TypeLiteral<Map<String, MessageProducerPlugin>> messageProducerPluginMapKey =
-                new TypeLiteral<Map<String, MessageProducerPlugin>>(){};
+            new TypeLiteral<Map<String, MessageProducerPlugin>>(){};
         final Map<String, MessageProducerPlugin> messageProducerPluginMap =
-                serviceInjector.getInstance(Key.get(messageProducerPluginMapKey));
+            serviceInjector.getInstance(Key.get(messageProducerPluginMapKey));
         assertThat(messageProducerPluginMap, aMapWithSize(1));
         assertThat(messageProducerPluginMap, hasKey("blockingQueue"));
     }
@@ -165,9 +187,9 @@ public class SampleDropwizardWebAppFTest {
         final Injector serviceInjector = webAppDelegate.getServiceInjector();
 
         final TypeLiteral<Map<String, ModelSerializer>> modelSerializerMapKey =
-                new TypeLiteral<Map<String, ModelSerializer>>(){};
+            new TypeLiteral<Map<String, ModelSerializer>>(){};
         final Map<String, ModelSerializer> modelSerializerMap =
-                serviceInjector.getInstance(Key.get(modelSerializerMapKey));
+            serviceInjector.getInstance(Key.get(modelSerializerMapKey));
         assertThat(modelSerializerMap, aMapWithSize(1));
         assertThat(modelSerializerMap, hasKey("pojo"));
     }

--- a/app-dropwizard-test/src/test/java/net/spals/appbuilder/app/dropwizard/TracingDropwizardWebAppFTest.java
+++ b/app-dropwizard-test/src/test/java/net/spals/appbuilder/app/dropwizard/TracingDropwizardWebAppFTest.java
@@ -25,7 +25,7 @@ import static org.hamcrest.Matchers.*;
 public class TracingDropwizardWebAppFTest {
 
     private final DropwizardTestSupport<Configuration> testServerWrapper =
-            new DropwizardTestSupport<>(TracingDropwizardWebApp.class, new Configuration());
+        new DropwizardTestSupport<>(TracingDropwizardWebApp.class, new Configuration());
     private MockTracer mockTracer;
 
     private final Client webClient = ClientBuilder.newClient();
@@ -49,14 +49,16 @@ public class TracingDropwizardWebAppFTest {
     @DataProvider
     Object[][] serverRequestTracingProvider() {
         return new Object[][] {
-                {"tracing/noAnnotation", "tracing/noAnnotation"},
-                {"tracing/withAnnotation", "customOperationName"},
+            {"tracing/noAnnotation", "tracing/noAnnotation"},
+            {"tracing/withAnnotation", "customOperationName"},
         };
     }
 
     @Test(dataProvider = "serverRequestTracingProvider")
-    public void testServerRequestTracing(final String path,
-                                         final String expectedOperationName) {
+    public void testServerRequestTracing(
+        final String path,
+        final String expectedOperationName
+    ) {
         final String target = "http://localhost:" + testServerWrapper.getLocalPort() + "/" + path;
         final WebTarget webTarget = webClient.target(target);
         webTarget.request().get();

--- a/app-dropwizard-test/src/test/java/net/spals/appbuilder/app/dropwizard/plugins/PluginsDropwizardWebApp.java
+++ b/app-dropwizard-test/src/test/java/net/spals/appbuilder/app/dropwizard/plugins/PluginsDropwizardWebApp.java
@@ -10,6 +10,7 @@ import net.spals.appbuilder.app.dropwizard.DropwizardWebApp;
 import net.spals.appbuilder.config.service.ServiceScan;
 import net.spals.appbuilder.filestore.core.FileStore;
 import net.spals.appbuilder.graph.model.ServiceGraphFormat;
+import net.spals.appbuilder.keystore.core.KeyStore;
 import net.spals.appbuilder.mapstore.core.MapStore;
 import net.spals.appbuilder.message.core.MessageConsumer;
 import net.spals.appbuilder.message.core.MessageProducer;
@@ -49,6 +50,7 @@ public class PluginsDropwizardWebApp extends Application<Configuration> {
             .setServiceScan(new ServiceScan.Builder()
                 .addServicePackages("net.spals.appbuilder.app.dropwizard.plugins")
                 .addServicePlugins("net.spals.appbuilder.filestore.s3", FileStore.class)
+                .addDefaultServices(KeyStore.class)
                 .addServicePlugins("net.spals.appbuilder.mapstore.cassandra", MapStore.class)
                 .addServicePlugins("net.spals.appbuilder.mapstore.dynamodb", MapStore.class)
                 .addServicePlugins("net.spals.appbuilder.message.kafka", MessageConsumer.class, MessageProducer.class)

--- a/app-dropwizard-test/src/test/java/net/spals/appbuilder/app/dropwizard/plugins/PluginsDropwizardWebApp.java
+++ b/app-dropwizard-test/src/test/java/net/spals/appbuilder/app/dropwizard/plugins/PluginsDropwizardWebApp.java
@@ -53,6 +53,7 @@ public class PluginsDropwizardWebApp extends Application<Configuration> {
                 .addDefaultServices(KeyStore.class)
                 .addServicePlugins("net.spals.appbuilder.mapstore.cassandra", MapStore.class)
                 .addServicePlugins("net.spals.appbuilder.mapstore.dynamodb", MapStore.class)
+                .addServicePlugins("net.spals.appbuilder.mapstore.mongodb", MapStore.class)
                 .addServicePlugins("net.spals.appbuilder.message.kafka", MessageConsumer.class, MessageProducer.class)
                 .addServicePlugins("net.spals.appbuilder.message.kinesis", MessageConsumer.class, MessageProducer.class)
                 .addServicePlugins("net.spals.appbuilder.model.protobuf", ModelSerializer.class)

--- a/app-dropwizard-test/src/test/java/net/spals/appbuilder/app/dropwizard/sample/SampleDropwizardWebApp.java
+++ b/app-dropwizard-test/src/test/java/net/spals/appbuilder/app/dropwizard/sample/SampleDropwizardWebApp.java
@@ -9,6 +9,7 @@ import net.spals.appbuilder.app.dropwizard.DropwizardWebApp;
 import net.spals.appbuilder.config.service.ServiceScan;
 import net.spals.appbuilder.filestore.core.FileStore;
 import net.spals.appbuilder.graph.model.ServiceGraphFormat;
+import net.spals.appbuilder.keystore.core.KeyStore;
 import net.spals.appbuilder.mapstore.core.MapStore;
 import net.spals.appbuilder.message.core.MessageConsumer;
 import net.spals.appbuilder.message.core.MessageProducer;
@@ -49,6 +50,7 @@ public class SampleDropwizardWebApp extends Application<Configuration> {
             .setServiceScan(new ServiceScan.Builder()
                 .addServicePackages("net.spals.appbuilder.app.dropwizard.sample")
                 .addDefaultServices(FileStore.class)
+                .addDefaultServices(KeyStore.class)
                 .addDefaultServices(MapStore.class)
                 .addDefaultServices(MessageConsumer.class, MessageProducer.class)
                 .addDefaultServices(ModelSerializer.class)

--- a/app-dropwizard-test/src/test/resources/config/plugins-dropwizard-service.conf
+++ b/app-dropwizard-test/src/test/resources/config/plugins-dropwizard-service.conf
@@ -7,7 +7,7 @@ fileStore.localFS.basePath=${HOME}"/.localFS"
 fileStore.localFS.basePath=${?LOCALFS_BASE_PATH}
 
 fileStore.s3.awsAccessKeyId="IZFBRDUMMYVMNQAJVEQR"
-fileStore.s3.awsSecretKey="ALle9zdW47DUMMYiSALhBwMDIEkndJt6JDVx7mt"
+fileStore.s3.awsSecretKey="ENC(C9JymP6lBa0GJQpGHvpyYDrOf0GPdxsW+HnoA3+knK8BR+2csC/BJLjvp4YL5uFf)"
 fileStore.s3.endpoint="us-west-2"
 
 ### KeyStore configuration ###
@@ -22,7 +22,7 @@ mapStore.cassandra.clusterName="MyCassandraCluster"
 mapStore.cassandra.hosts="192.168.0.1,192.168.0.2"
 
 mapStore.dynamoDB.awsAccessKeyId="IZFBRDUMMYVMNQAJVEQR"
-mapStore.dynamoDB.awsSecretKey="ALle9zdW47DUMMYiSALhBwMDIEkndJt6JDVx7mt"
+mapStore.dynamoDB.awsSecretKey="ENC(C9JymP6lBa0GJQpGHvpyYDrOf0GPdxsW+HnoA3+knK8BR+2csC/BJLjvp4YL5uFf)"
 mapStore.dynamoDB.endpoint="us-west-2"
 
 mapStore.mapDB.file=${HOME}"/.mapDB_dropwizard_plugins"
@@ -39,7 +39,7 @@ kafkaNotifications.consumer.globalId="plugins-kafka-notifications-consumer"
 kafkaNotifications.consumer.source="kafka"
 
 messageConsumer.kinesis.awsAccessKeyId="IZFBRDUMMYVMNQAJVEQR"
-messageConsumer.kinesis.awsSecretKey="ALle9zdW47DUMMYiSALhBwMDIEkndJt6JDVx7mt"
+messageConsumer.kinesis.awsSecretKey="ENC(C9JymP6lBa0GJQpGHvpyYDrOf0GPdxsW+HnoA3+knK8BR+2csC/BJLjvp4YL5uFf)"
 messageConsumer.kinesis.endpoint="us-west-2"
 
 kinesisNotifications.consumer.channel="notifications"
@@ -58,7 +58,7 @@ kafkaNotifications.producer.globalId="plugins-kafka-notifications-producer"
 kafkaNotifications.producer.destination="kafka"
 
 messageProducer.kinesis.awsAccessKeyId="IZB//DUMMY//MQAJVEQR"
-messageProducer.kinesis.awsSecretKey="ALle9zW4//DUMMY//SAhBwMDIEkndJt6JDVx7mt"
+messageProducer.kinesis.awsSecretKey="ENC(C9JymP6lBa0GJQpGHvpyYDrOf0GPdxsW+HnoA3+knK8BR+2csC/BJLjvp4YL5uFf)"
 messageProducer.kinesis.endpoint="us-west-2"
 
 kinesisNotifications.producer.channel="notifications"

--- a/app-dropwizard-test/src/test/resources/config/plugins-dropwizard-service.conf
+++ b/app-dropwizard-test/src/test/resources/config/plugins-dropwizard-service.conf
@@ -28,6 +28,10 @@ mapStore.dynamoDB.endpoint="us-west-2"
 mapStore.mapDB.file=${HOME}"/.mapDB_dropwizard_plugins"
 mapStore.mapDB.file=${?MAPDB_MAPSTORE_FILE}
 
+mapStore.mongoDB.host="192.168.0.1"
+mapStore.mongoDB.port=27017
+mapStore.mongoDB.database="my_database"
+
 
 ### MessageConsumer configuration ###
 

--- a/app-dropwizard-test/src/test/resources/config/plugins-dropwizard-service.conf
+++ b/app-dropwizard-test/src/test/resources/config/plugins-dropwizard-service.conf
@@ -10,6 +10,10 @@ fileStore.s3.awsAccessKeyId="IZFBRDUMMYVMNQAJVEQR"
 fileStore.s3.awsSecretKey="ALle9zdW47DUMMYiSALhBwMDIEkndJt6JDVx7mt"
 fileStore.s3.endpoint="us-west-2"
 
+### KeyStore configuration ###
+keyStore.system="password"
+
+keyStore.password.pwd="myPassword"
 
 ### MapStore configuration ###
 mapStore.system="mapDB"

--- a/app-dropwizard-test/src/test/resources/config/sample-dropwizard-service.conf
+++ b/app-dropwizard-test/src/test/resources/config/sample-dropwizard-service.conf
@@ -6,6 +6,11 @@ fileStore.system="localFS"
 fileStore.localFS.basePath=${HOME}"/.localFS"
 fileStore.localFS.basePath=${?LOCALFS_BASE_PATH}
 
+### KeyStore configuration ###
+keyStore.system="password"
+
+keyStore.password.pwd="myPassword"
+
 ### MapStore configuration ###
 mapStore.system="mapDB"
 

--- a/app-finatra-test/pom.xml
+++ b/app-finatra-test/pom.xml
@@ -93,6 +93,10 @@
         </dependency>
         <dependency>
             <groupId>net.spals.appbuilder.plugins</groupId>
+            <artifactId>spals-appbuilder-mapstore-mongodb</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>net.spals.appbuilder.plugins</groupId>
             <artifactId>spals-appbuilder-message-kafka</artifactId>
         </dependency>
         <dependency>

--- a/app-finatra-test/src/test/resources/config/plugins-finatra-service.conf
+++ b/app-finatra-test/src/test/resources/config/plugins-finatra-service.conf
@@ -30,6 +30,9 @@ mapStore.dynamoDB.endpoint="us-west-2"
 mapStore.mapDB.file=${HOME}"/.mapDB_finatra_plugins"
 mapStore.mapDB.file=${?MAPDB_MAPSTORE_FILE}
 
+mapStore.mongoDB.host="192.168.0.1"
+mapStore.mongoDB.port=27017
+mapStore.mongoDB.database="my_database"
 
 ### MessageConsumer configuration ###
 

--- a/app-finatra-test/src/test/resources/config/plugins-finatra-service.conf
+++ b/app-finatra-test/src/test/resources/config/plugins-finatra-service.conf
@@ -7,8 +7,14 @@ fileStore.localFS.basePath=${HOME}"/.localFS"
 fileStore.localFS.basePath=${?LOCALFS_BASE_PATH}
 
 fileStore.s3.awsAccessKeyId="IZFBRDUMMYVMNQAJVEQR"
-fileStore.s3.awsSecretKey="ALle9zdW47DUMMYiSALhBwMDIEkndJt6JDVx7mt"
+fileStore.s3.awsSecretKey="ENC(C9JymP6lBa0GJQpGHvpyYDrOf0GPdxsW+HnoA3+knK8BR+2csC/BJLjvp4YL5uFf)"
 fileStore.s3.endpoint="us-west-2"
+
+
+### KeyStore configuration ###
+keyStore.system="password"
+
+keyStore.password.pwd="myPassword"
 
 
 ### MapStore configuration ###
@@ -18,7 +24,7 @@ mapStore.cassandra.clusterName="MyCassandraCluster"
 mapStore.cassandra.hosts="192.168.0.1,192.168.0.2"
 
 mapStore.dynamoDB.awsAccessKeyId="IZB//DUMMY//MQAJVEQR"
-mapStore.dynamoDB.awsSecretKey="ALle9zW4//DUMMY//SAhBwMDIEkndJt6JDVx7mt"
+mapStore.dynamoDB.awsSecretKey="ENC(C9JymP6lBa0GJQpGHvpyYDrOf0GPdxsW+HnoA3+knK8BR+2csC/BJLjvp4YL5uFf)"
 mapStore.dynamoDB.endpoint="us-west-2"
 
 mapStore.mapDB.file=${HOME}"/.mapDB_finatra_plugins"
@@ -35,7 +41,7 @@ kafkaNotifications.consumer.globalId="plugins-kafka-notifications-consumer"
 kafkaNotifications.consumer.source="kafka"
 
 messageConsumer.kinesis.awsAccessKeyId="IZFBRDUMMYVMNQAJVEQR"
-messageConsumer.kinesis.awsSecretKey="ALle9zdW47DUMMYiSALhBwMDIEkndJt6JDVx7mt"
+messageConsumer.kinesis.awsSecretKey="ENC(C9JymP6lBa0GJQpGHvpyYDrOf0GPdxsW+HnoA3+knK8BR+2csC/BJLjvp4YL5uFf)"
 messageConsumer.kinesis.endpoint="us-west-2"
 
 kinesisNotifications.consumer.channel="notifications"
@@ -54,7 +60,7 @@ kafkaNotifications.producer.globalId="plugins-kafka-notifications-producer"
 kafkaNotifications.producer.destination="kafka"
 
 messageProducer.kinesis.awsAccessKeyId="IZB//DUMMY//MQAJVEQR"
-messageProducer.kinesis.awsSecretKey="ALle9zW4//DUMMY//SAhBwMDIEkndJt6JDVx7mt"
+messageProducer.kinesis.awsSecretKey="ENC(C9JymP6lBa0GJQpGHvpyYDrOf0GPdxsW+HnoA3+knK8BR+2csC/BJLjvp4YL5uFf)"
 messageProducer.kinesis.endpoint="us-west-2"
 
 kinesisNotifications.producer.channel="notifications"

--- a/app-finatra-test/src/test/resources/config/sample-finatra-service.conf
+++ b/app-finatra-test/src/test/resources/config/sample-finatra-service.conf
@@ -6,6 +6,11 @@ fileStore.system="localFS"
 fileStore.localFS.basePath=${HOME}"/.localFS"
 fileStore.localFS.basePath=${?LOCALFS_BASE_PATH}
 
+### KeyStore configuration ###
+keyStore.system="password"
+
+keyStore.password.pwd="myPassword"
+
 ### MapStore configuration ###
 mapStore.system="mapDB"
 

--- a/app-finatra-test/src/test/scala/net/spals/appbuilder/app/finatra/PluginsFinatraWebAppFTest.scala
+++ b/app-finatra-test/src/test/scala/net/spals/appbuilder/app/finatra/PluginsFinatraWebAppFTest.scala
@@ -66,10 +66,11 @@ class PluginsFinatraWebAppFTest {
 
     val mapStorePluginMapKey = new TypeLiteral[java.util.Map[String, MapStorePlugin]](){}
     val mapStorePluginMap = serviceInjector.getInstance(Key.get(mapStorePluginMapKey))
-    assertThat(mapStorePluginMap, Matchers.aMapWithSize[String, MapStorePlugin](3))
+    assertThat(mapStorePluginMap, Matchers.aMapWithSize[String, MapStorePlugin](4))
     assertThat(mapStorePluginMap, hasKey("cassandra"))
     assertThat(mapStorePluginMap, hasKey("dynamoDB"))
     assertThat(mapStorePluginMap, hasKey("mapDB"))
+    assertThat(mapStorePluginMap, hasKey("mongoDB"))
   }
 
   @Test def testCassandraMapStoreInjection() {

--- a/app-finatra-test/src/test/scala/net/spals/appbuilder/app/finatra/PluginsFinatraWebAppFTest.scala
+++ b/app-finatra-test/src/test/scala/net/spals/appbuilder/app/finatra/PluginsFinatraWebAppFTest.scala
@@ -6,6 +6,7 @@ import com.google.inject.{Key, Stage, TypeLiteral}
 import com.twitter.finatra.http.EmbeddedHttpServer
 import net.spals.appbuilder.app.finatra.plugins.PluginsFinatraWebApp
 import net.spals.appbuilder.filestore.core.{FileStore, FileStorePlugin}
+import net.spals.appbuilder.keystore.core.{KeyStore, KeyStorePlugin}
 import net.spals.appbuilder.mapstore.core.{MapStore, MapStorePlugin}
 import net.spals.appbuilder.message.core.consumer.MessageConsumerPlugin
 import net.spals.appbuilder.message.core.producer.MessageProducerPlugin
@@ -47,6 +48,16 @@ class PluginsFinatraWebAppFTest {
     assertThat(fileStorePluginMap, Matchers.aMapWithSize[String, FileStorePlugin](2))
     assertThat(fileStorePluginMap, hasKey("localFS"))
     assertThat(fileStorePluginMap, hasKey("s3"))
+  }
+
+  @Test def testKeyStoreInjection() {
+    val serviceInjector = pluginsApp.getServiceInjector
+    assertThat(serviceInjector.getInstance(classOf[KeyStore]), notNullValue())
+
+    val keyStorePluginMapKey = new TypeLiteral[java.util.Map[String, KeyStorePlugin]]() {}
+    val keyStorePluginMap = serviceInjector.getInstance(Key.get(keyStorePluginMapKey))
+    assertThat(keyStorePluginMap, Matchers.aMapWithSize[String, KeyStorePlugin](1))
+    assertThat(keyStorePluginMap, hasKey("password"))
   }
 
   @Test def testMapStoreInjection() {

--- a/app-finatra-test/src/test/scala/net/spals/appbuilder/app/finatra/SampleFinatraWebAppFTest.scala
+++ b/app-finatra-test/src/test/scala/net/spals/appbuilder/app/finatra/SampleFinatraWebAppFTest.scala
@@ -9,6 +9,7 @@ import net.spals.appbuilder.app.finatra.sample.web.{SampleFinatraController, Sam
 import net.spals.appbuilder.app.finatra.sample.{SampleFinatraCustomService, SampleFinatraWebApp}
 import net.spals.appbuilder.executor.core.ExecutorServiceFactory
 import net.spals.appbuilder.filestore.core.{FileStore, FileStorePlugin}
+import net.spals.appbuilder.keystore.core.{KeyStore, KeyStorePlugin}
 import net.spals.appbuilder.mapstore.core.{MapStore, MapStorePlugin}
 import net.spals.appbuilder.message.core.consumer.MessageConsumerPlugin
 import net.spals.appbuilder.message.core.producer.MessageProducerPlugin
@@ -45,6 +46,7 @@ class SampleFinatraWebAppFTest {
   @DataProvider def serviceConfigProvider(): Array[Array[AnyRef]] = {
     Array(
       Array("fileStore.system", "localFS"),
+      Array("keyStore.system", "password"),
       Array("mapStore.system", "mapDB")
     )
   }
@@ -96,6 +98,16 @@ class SampleFinatraWebAppFTest {
     val fileStorePluginMap = serviceInjector.getInstance(Key.get(fileStorePluginMapKey))
     assertThat(fileStorePluginMap, Matchers.aMapWithSize[String, FileStorePlugin](1))
     assertThat(fileStorePluginMap, hasKey("localFS"))
+  }
+
+  @Test def testKeyStoreInjection() {
+    val serviceInjector = sampleApp.getServiceInjector
+    assertThat(serviceInjector.getInstance(classOf[KeyStore]), notNullValue())
+
+    val keyStorePluginMapKey = new TypeLiteral[java.util.Map[String, KeyStorePlugin]](){}
+    val keyStorePluginMap = serviceInjector.getInstance(Key.get(keyStorePluginMapKey))
+    assertThat(keyStorePluginMap, Matchers.aMapWithSize[String, KeyStorePlugin](1))
+    assertThat(keyStorePluginMap, hasKey("password"))
   }
 
   @Test def testMapStoreInjection() {

--- a/app-finatra-test/src/test/scala/net/spals/appbuilder/app/finatra/plugins/PluginsFinatraWebApp.scala
+++ b/app-finatra-test/src/test/scala/net/spals/appbuilder/app/finatra/plugins/PluginsFinatraWebApp.scala
@@ -27,6 +27,7 @@ private[finatra] class PluginsFinatraWebApp extends FinatraWebApp {
     .addDefaultServices(classOf[KeyStore])
     .addServicePlugins("net.spals.appbuilder.mapstore.cassandra", classOf[MapStore])
     .addServicePlugins("net.spals.appbuilder.mapstore.dynamodb", classOf[MapStore])
+    .addServicePlugins("net.spals.appbuilder.mapstore.mongodb", classOf[MapStore])
     .addServicePlugins("net.spals.appbuilder.message.kafka", classOf[MessageConsumer], classOf[MessageProducer])
     .addServicePlugins("net.spals.appbuilder.message.kinesis", classOf[MessageConsumer], classOf[MessageProducer])
     .addServicePlugins("net.spals.appbuilder.model.protobuf", classOf[ModelSerializer])

--- a/app-finatra-test/src/test/scala/net/spals/appbuilder/app/finatra/plugins/PluginsFinatraWebApp.scala
+++ b/app-finatra-test/src/test/scala/net/spals/appbuilder/app/finatra/plugins/PluginsFinatraWebApp.scala
@@ -5,6 +5,7 @@ import net.spals.appbuilder.app.finatra.FinatraWebApp
 import net.spals.appbuilder.config.service.ServiceScan
 import net.spals.appbuilder.filestore.core.FileStore
 import net.spals.appbuilder.graph.model.ServiceGraphFormat
+import net.spals.appbuilder.keystore.core.KeyStore
 import net.spals.appbuilder.mapstore.core.MapStore
 import net.spals.appbuilder.message.core.{MessageConsumer, MessageProducer}
 import net.spals.appbuilder.model.core.ModelSerializer
@@ -23,6 +24,7 @@ private[finatra] class PluginsFinatraWebApp extends FinatraWebApp {
   setServiceScan(new ServiceScan.Builder()
     .addServicePackages("net.spals.appbuilder.app.finatra.plugins")
     .addServicePlugins("net.spals.appbuilder.filestore.s3", classOf[FileStore])
+    .addDefaultServices(classOf[KeyStore])
     .addServicePlugins("net.spals.appbuilder.mapstore.cassandra", classOf[MapStore])
     .addServicePlugins("net.spals.appbuilder.mapstore.dynamodb", classOf[MapStore])
     .addServicePlugins("net.spals.appbuilder.message.kafka", classOf[MessageConsumer], classOf[MessageProducer])

--- a/app-finatra-test/src/test/scala/net/spals/appbuilder/app/finatra/sample/SampleFinatraWebApp.scala
+++ b/app-finatra-test/src/test/scala/net/spals/appbuilder/app/finatra/sample/SampleFinatraWebApp.scala
@@ -5,6 +5,7 @@ import net.spals.appbuilder.app.finatra.FinatraWebApp
 import net.spals.appbuilder.config.service.ServiceScan
 import net.spals.appbuilder.filestore.core.FileStore
 import net.spals.appbuilder.graph.model.ServiceGraphFormat
+import net.spals.appbuilder.keystore.core.KeyStore
 import net.spals.appbuilder.mapstore.core.MapStore
 import net.spals.appbuilder.message.core.{MessageConsumer, MessageProducer}
 import net.spals.appbuilder.model.core.ModelSerializer
@@ -27,6 +28,7 @@ private[finatra] class SampleFinatraWebApp extends FinatraWebApp {
   setServiceScan(new ServiceScan.Builder()
     .addServicePackages("net.spals.appbuilder.app.finatra.sample")
     .addDefaultServices(classOf[FileStore])
+    .addDefaultServices(classOf[KeyStore])
     .addDefaultServices(classOf[MapStore])
     .addDefaultServices(classOf[MessageConsumer], classOf[MessageProducer])
     .addDefaultServices(classOf[ModelSerializer])

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -52,6 +52,10 @@
         </dependency>
         <dependency>
             <groupId>net.spals.appbuilder</groupId>
+            <artifactId>spals-appbuilder-keystore-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>net.spals.appbuilder</groupId>
             <artifactId>spals-appbuilder-mapstore-core</artifactId>
         </dependency>
         <dependency>

--- a/config/pom.xml
+++ b/config/pom.xml
@@ -35,6 +35,10 @@
             <artifactId>config</artifactId>
         </dependency>
         <dependency>
+            <groupId>net.spals.appbuilder</groupId>
+            <artifactId>spals-appbuilder-keystore-core</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.inferred</groupId>
             <artifactId>freebuilder</artifactId>
         </dependency>

--- a/config/src/main/java/net/spals/appbuilder/config/provider/TypesafeConfigurationProvider.java
+++ b/config/src/main/java/net/spals/appbuilder/config/provider/TypesafeConfigurationProvider.java
@@ -2,15 +2,22 @@ package net.spals.appbuilder.config.provider;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
+import com.google.common.annotations.VisibleForTesting;
 import com.netflix.governator.configuration.*;
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigException;
+import net.spals.appbuilder.keystore.core.KeyStore;
+import net.spals.appbuilder.keystore.core.KeyStoreProvider;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.util.Date;
 import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 /**
@@ -20,9 +27,13 @@ import java.util.stream.Collectors;
  * @author tkral
  */
 public class TypesafeConfigurationProvider extends DefaultConfigurationProvider {
+    @VisibleForTesting
+    static final Pattern ENCRYPTED_PATTERN = Pattern.compile("^ENC\\((.*)\\)");
     private static final Logger LOGGER = LoggerFactory.getLogger(TypesafeConfigurationProvider.class);
 
     private final Config config;
+
+    private final AtomicReference<KeyStore> keyStoreRef = new AtomicReference<>();
     private final ObjectMapper mapper = new ObjectMapper()
             .registerModule(new Jdk8Module());
 
@@ -97,7 +108,28 @@ public class TypesafeConfigurationProvider extends DefaultConfigurationProvider 
             @Override
             public String get() {
                 try {
-                    return config.getString(key.getRawKey());
+                    final String stringProperty = config.getString(key.getRawKey());
+                    // Check to see if the string property is encrypted
+                    final Matcher encryptedMatcher = ENCRYPTED_PATTERN.matcher(stringProperty);
+                    if (encryptedMatcher.matches()) {
+                        final String encryptedStringProperty = encryptedMatcher.group(1);
+                        try {
+                            // KeyStores may be expensive to set up, so ensure that we only load it once
+                            // (or, at least, try our best to ensure)
+                            final KeyStore keyStore = Optional.ofNullable(keyStoreRef.get())
+                                .orElseGet(() -> {
+                                    keyStoreRef.compareAndSet(null, KeyStoreProvider.createKeyStore(config));
+                                    return keyStoreRef.get();
+                                });
+                            return keyStore.decrypt(encryptedStringProperty);
+                        } catch (ConfigException e) {
+                            throw new ConfigException.Generic(
+                                "The configuration uses an encrypted value at " + key.getRawKey() +
+                                    ", but it is not set up to handle encrypted values", e);
+                        }
+                    }
+
+                    return stringProperty;
                 } catch (ConfigException.Missing e) {
                     return defaultValue;
                 }

--- a/config/src/main/java/net/spals/appbuilder/config/provider/TypesafeConfigurationProvider.java
+++ b/config/src/main/java/net/spals/appbuilder/config/provider/TypesafeConfigurationProvider.java
@@ -3,6 +3,8 @@ package net.spals.appbuilder.config.provider;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Supplier;
+import com.google.common.base.Suppliers;
 import com.netflix.governator.configuration.*;
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigException;
@@ -14,8 +16,6 @@ import org.slf4j.LoggerFactory;
 import java.io.IOException;
 import java.util.Date;
 import java.util.Map;
-import java.util.Optional;
-import java.util.concurrent.atomic.AtomicReference;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -32,13 +32,14 @@ public class TypesafeConfigurationProvider extends DefaultConfigurationProvider 
     private static final Logger LOGGER = LoggerFactory.getLogger(TypesafeConfigurationProvider.class);
 
     private final Config config;
+    private final Supplier<KeyStore> keyStoreSupplier;
 
-    private final AtomicReference<KeyStore> keyStoreRef = new AtomicReference<>();
     private final ObjectMapper mapper = new ObjectMapper()
             .registerModule(new Jdk8Module());
 
     public TypesafeConfigurationProvider(final Config config) {
         this.config = config;
+        this.keyStoreSupplier = Suppliers.memoize(() -> KeyStoreProvider.createKeyStore(config));
     }
 
     @Override
@@ -114,13 +115,7 @@ public class TypesafeConfigurationProvider extends DefaultConfigurationProvider 
                     if (encryptedMatcher.matches()) {
                         final String encryptedStringProperty = encryptedMatcher.group(1);
                         try {
-                            // KeyStores may be expensive to set up, so ensure that we only load it once
-                            // (or, at least, try our best to ensure)
-                            final KeyStore keyStore = Optional.ofNullable(keyStoreRef.get())
-                                .orElseGet(() -> {
-                                    keyStoreRef.compareAndSet(null, KeyStoreProvider.createKeyStore(config));
-                                    return keyStoreRef.get();
-                                });
+                            final KeyStore keyStore = keyStoreSupplier.get();
                             return keyStore.decrypt(encryptedStringProperty);
                         } catch (ConfigException e) {
                             throw new ConfigException.Generic(

--- a/keystore-core-test/pom.xml
+++ b/keystore-core-test/pom.xml
@@ -1,0 +1,43 @@
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+    <parent>
+        <groupId>net.spals.appbuilder</groupId>
+        <artifactId>spals-appbuilder-parent</artifactId>
+        <version>0.3.1-SNAPSHOT</version>
+    </parent>
+
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>net.spals.appbuilder</groupId>
+    <artifactId>spals-appbuilder-keystore-core-test</artifactId>
+    <version>0.3.1-SNAPSHOT</version>
+    <packaging>jar</packaging>
+
+    <dependencies>
+        <dependency>
+            <groupId>eu.codearte.catch-exception</groupId>
+            <artifactId>catch-exception</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>eu.codearte.catch-exception</groupId>
+            <artifactId>catch-throwable</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>net.spals.appbuilder</groupId>
+            <artifactId>spals-appbuilder-keystore-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>java-hamcrest</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.testng</groupId>
+            <artifactId>testng</artifactId>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/keystore-core-test/src/test/java/net/spals/appbuilder/keystore/core/PasswordKeyStorePluginTest.java
+++ b/keystore-core-test/src/test/java/net/spals/appbuilder/keystore/core/PasswordKeyStorePluginTest.java
@@ -1,0 +1,105 @@
+package net.spals.appbuilder.keystore.core;
+
+import com.google.common.collect.ImmutableMap;
+import com.typesafe.config.Config;
+import com.typesafe.config.ConfigException;
+import com.typesafe.config.ConfigFactory;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import static com.googlecode.catchexception.CatchException.catchException;
+import static com.googlecode.catchexception.CatchException.caughtException;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+
+/**
+ * Unit tests for {@link PasswordKeyStorePlugin}.
+ *
+ * @author tkral
+ */
+public class PasswordKeyStorePluginTest {
+
+    @Test
+    public void testCreatePasswordKeyStore() {
+        final Config serviceConfig = ConfigFactory.parseMap(ImmutableMap.of("keyStore.password.pwd", "myPassword"));
+        final KeyStore keyStore = PasswordKeyStorePlugin.createPasswordKeyStore(serviceConfig);
+
+        assertThat(keyStore, notNullValue(KeyStore.class));
+        assertThat(keyStore.encrypt(""), notNullValue(String.class));
+        assertThat(keyStore.encryptBytes(new byte[0]), notNullValue(byte[].class));
+    }
+
+    @Test
+    public void testCreatePasswordKeyStoreNoConfig() {
+        catchException(() -> PasswordKeyStorePlugin.createPasswordKeyStore(ConfigFactory.empty()));
+        assertThat(caughtException(), instanceOf(ConfigException.Missing.class));
+    }
+
+    @Test
+    public void testPasswordCleanup() {
+        final PasswordKeyStorePlugin keyStorePlugin = new PasswordKeyStorePlugin();
+        keyStorePlugin.password = "myPassword";
+        keyStorePlugin.postConstruct();
+
+        assertThat(keyStorePlugin.password, nullValue(String.class));
+    }
+
+    @Test
+    public void testEncryptNullString() {
+        final PasswordKeyStorePlugin keyStorePlugin = new PasswordKeyStorePlugin();
+        keyStorePlugin.password = "myPassword";
+        keyStorePlugin.postConstruct();
+
+        final String encrypted = keyStorePlugin.encrypt(null);
+        assertThat(encrypted, nullValue(String.class));
+
+        final String decrypted = keyStorePlugin.decrypt(encrypted);
+        assertThat(decrypted, nullValue(String.class));
+    }
+
+    @DataProvider
+    Object[][] encryptDecryptStringProvider() {
+        return new Object[][] {
+            // Case: Empty string
+            {""},
+            {"The quick brown cat"},
+        };
+    }
+
+    @Test(dataProvider = "encryptDecryptStringProvider")
+    public void testEncryptDecryptString(final String str) {
+        final PasswordKeyStorePlugin keyStorePlugin = new PasswordKeyStorePlugin();
+        keyStorePlugin.password = "myPassword";
+        keyStorePlugin.postConstruct();
+
+        final String encrypted = keyStorePlugin.encrypt(str);
+        assertThat(encrypted, not(is(str)));
+
+        final String decrypted = keyStorePlugin.decrypt(encrypted);
+        assertThat(decrypted, is(str));
+    }
+
+    @DataProvider
+    Object[][] encryptDecryptBytesProvider() {
+        return new Object[][] {
+            // Empty byte array
+            {new byte[0]},
+            // Case: Zeroed byte array
+            {new byte[]{0, 0, 0}},
+            {new byte[]{1, 2, 3}},
+        };
+    }
+
+    @Test(dataProvider = "encryptDecryptBytesProvider")
+    public void testEncryptDecryptBytes(final byte[] bytes) {
+        final PasswordKeyStorePlugin keyStorePlugin = new PasswordKeyStorePlugin();
+        keyStorePlugin.password = "myPassword";
+        keyStorePlugin.postConstruct();
+
+        final byte[] encrypted = keyStorePlugin.encryptBytes(bytes);
+        assertThat(encrypted, is(not(bytes)));
+
+        final byte[] decrypted = keyStorePlugin.decryptBytes(encrypted);
+        assertThat(decrypted, is(bytes));
+    }
+}

--- a/keystore-core/pom.xml
+++ b/keystore-core/pom.xml
@@ -1,0 +1,47 @@
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+    <parent>
+        <groupId>net.spals.appbuilder</groupId>
+        <artifactId>spals-appbuilder-parent</artifactId>
+        <version>0.3.1-SNAPSHOT</version>
+    </parent>
+
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>net.spals.appbuilder</groupId>
+    <artifactId>spals-appbuilder-keystore-core</artifactId>
+    <version>0.3.1-SNAPSHOT</version>
+    <packaging>jar</packaging>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.google.inject</groupId>
+            <artifactId>guice</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.netflix.governator</groupId>
+            <artifactId>governator-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.typesafe</groupId>
+            <artifactId>config</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>javax.validation</groupId>
+            <artifactId>validation-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>net.spals.appbuilder</groupId>
+            <artifactId>spals-appbuilder-annotations</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.bouncycastle</groupId>
+            <artifactId>bcprov-jdk15on</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.jasypt</groupId>
+            <artifactId>jasypt</artifactId>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/keystore-core/src/main/java/net/spals/appbuilder/keystore/core/KeyStore.java
+++ b/keystore-core/src/main/java/net/spals/appbuilder/keystore/core/KeyStore.java
@@ -1,0 +1,37 @@
+package net.spals.appbuilder.keystore.core;
+
+/**
+ * A store which contains keys for encrypting
+ * and decrypting data.
+ * <p>
+ * *NOTE*: The semantics of any implementation
+ * of {@link KeyStore} represent a bi-directional
+ * encryption. This is generally useful for the
+ * following use cases:
+ * <p>
+ * + Encrypting sensitive configuration used
+ *   for third party services (e.g. passwords
+ *   or secret keys).
+ * <p>
+ * + Encrypting application-level data for
+ *   storage WITH THE EXCEPTION OF USER
+ *   AUTHENTICATION PASSWORDS
+ *   (e.g. credit card information)
+ * <p>
+ * A {@link KeyStore} *SHOULD NOT* be used
+ * to encrypt passwords which are used for
+ * user authentication in your application.
+ * Instead you should use a digest (like BCrypt).
+ *
+ * @author tkral
+ */
+public interface KeyStore {
+
+    String decrypt(String encryptedString);
+
+    byte[] decryptBytes(byte[] encryptedBytes);
+
+    String encrypt(String unencryptedString);
+
+    byte[] encryptBytes(byte[] unencryptedBytes);
+}

--- a/keystore-core/src/main/java/net/spals/appbuilder/keystore/core/KeyStore.java
+++ b/keystore-core/src/main/java/net/spals/appbuilder/keystore/core/KeyStore.java
@@ -27,11 +27,43 @@ package net.spals.appbuilder.keystore.core;
  */
 public interface KeyStore {
 
+    /**
+     * Decrypts the given {@link String}. This
+     * {@link String} should have previously
+     * been encrypted by {@link #encrypt(String)}.
+     *
+     * @return If encrypted, return the given {@link String}
+     * in its plaintext form. If not encrypted, returns
+     * an unknown value.
+     */
     String decrypt(String encryptedString);
 
+    /**
+     * Decrypts the given byte array. This
+     * byte array should have previously
+     * been encrypted by {@link #encryptBytes(byte[])}.
+     *
+     * @return If encrypted, return the given byte array
+     * in its plain, unencrypted form. If not encrypted, returns
+     * an unknown value.
+     */
     byte[] decryptBytes(byte[] encryptedBytes);
 
+    /**
+     * Encrypts the given {@link String}. This
+     * {@link String} should be in its original,
+     * plaintext form.
+     *
+     * @return An encrypted form of the {@link String}.
+     */
     String encrypt(String unencryptedString);
 
+    /**
+     * Encrypts the given byte array. This
+     * byte array should be in its original,
+     * form.
+     *
+     * @return An encrypted form of the byte array.
+     */
     byte[] encryptBytes(byte[] unencryptedBytes);
 }

--- a/keystore-core/src/main/java/net/spals/appbuilder/keystore/core/KeyStorePlugin.java
+++ b/keystore-core/src/main/java/net/spals/appbuilder/keystore/core/KeyStorePlugin.java
@@ -1,6 +1,10 @@
 package net.spals.appbuilder.keystore.core;
 
 /**
+ * Marks a plugin implmentation for a {@link KeyStore}.
+ * <p>
+ * This is used for type safety in the {@link KeyStoreProvider}.
+ *
  * @author tkral
  */
 public interface KeyStorePlugin extends KeyStore {  }

--- a/keystore-core/src/main/java/net/spals/appbuilder/keystore/core/KeyStorePlugin.java
+++ b/keystore-core/src/main/java/net/spals/appbuilder/keystore/core/KeyStorePlugin.java
@@ -1,0 +1,6 @@
+package net.spals.appbuilder.keystore.core;
+
+/**
+ * @author tkral
+ */
+public interface KeyStorePlugin extends KeyStore {  }

--- a/keystore-core/src/main/java/net/spals/appbuilder/keystore/core/KeyStoreProvider.java
+++ b/keystore-core/src/main/java/net/spals/appbuilder/keystore/core/KeyStoreProvider.java
@@ -1,0 +1,57 @@
+package net.spals.appbuilder.keystore.core;
+
+import com.google.inject.Inject;
+import com.google.inject.Provider;
+import com.netflix.governator.annotations.Configuration;
+import com.typesafe.config.Config;
+import com.typesafe.config.ConfigException;
+import net.spals.appbuilder.annotations.service.AutoBindProvider;
+
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * A {@link Provider} which provides a {@link KeyStore}.
+ *
+ * @author tkral
+ */
+@AutoBindProvider
+public class KeyStoreProvider implements Provider<KeyStore> {
+
+    /**
+     * Creates a {@link KeyStore} outside of dependency injection.
+     * <p>
+     * This can be used for use cases that fall outside of an
+     * application's dependency graph. In particular, this is useful
+     * for configuration encryption.
+     */
+    public static KeyStore createKeyStore(final Config serviceConfig) {
+        final String storeSystem = serviceConfig.getString("keyStore.system");
+
+        if ("password".equals(storeSystem)) {
+            return PasswordKeyStorePlugin.createPasswordKeyStore(serviceConfig);
+        }
+
+        throw new ConfigException.BadValue("keyStore.system",
+            "No Key Store plugin found for : " + storeSystem);
+    }
+
+    @Configuration("keyStore.system")
+    private volatile String storeSystem;
+
+    private final Map<String, KeyStorePlugin> storePluginMap;
+
+    @Inject
+    KeyStoreProvider(final Map<String, KeyStorePlugin> storePluginMap) {
+        this.storePluginMap = storePluginMap;
+    }
+
+    @Override
+    public KeyStore get() {
+        final KeyStorePlugin storePlugin = Optional.ofNullable(storePluginMap.get(storeSystem))
+            .orElseThrow(() -> new ConfigException.BadValue("keyStore.system",
+                "No Key Store plugin found for : " + storeSystem));
+
+        return storePlugin;
+    }
+}

--- a/keystore-core/src/main/java/net/spals/appbuilder/keystore/core/KeyStoreProvider.java
+++ b/keystore-core/src/main/java/net/spals/appbuilder/keystore/core/KeyStoreProvider.java
@@ -24,6 +24,10 @@ public class KeyStoreProvider implements Provider<KeyStore> {
      * This can be used for use cases that fall outside of an
      * application's dependency graph. In particular, this is useful
      * for configuration encryption.
+     *
+     * @return A new {@link KeyStore} based on the given {@link Config}.
+     * @throws ConfigException If the given {@link Config} is not properly
+     *         configured to create a {@link KeyStore} instance.
      */
     public static KeyStore createKeyStore(final Config serviceConfig) {
         final String storeSystem = serviceConfig.getString("keyStore.system");

--- a/keystore-core/src/main/java/net/spals/appbuilder/keystore/core/PasswordKeyStorePlugin.java
+++ b/keystore-core/src/main/java/net/spals/appbuilder/keystore/core/PasswordKeyStorePlugin.java
@@ -12,6 +12,7 @@ import org.jasypt.encryption.pbe.PooledPBEByteEncryptor;
 import org.jasypt.encryption.pbe.PooledPBEStringEncryptor;
 
 import javax.annotation.PostConstruct;
+import javax.validation.ValidationException;
 
 /**
  * A {@link KeyStorePlugin} which stores a single password
@@ -52,7 +53,9 @@ class PasswordKeyStorePlugin implements KeyStorePlugin {
     @VisibleForTesting
     void createEncryptors(String password) {
         if (password == null) {
-            throw new RuntimeException();
+            throw new ValidationException(
+                "may not be null - " + this.getClass().getName() + ".password = null"
+            );
         }
 
         final PooledPBEByteEncryptor pooledPBEByteEncryptor =

--- a/keystore-core/src/main/java/net/spals/appbuilder/keystore/core/PasswordKeyStorePlugin.java
+++ b/keystore-core/src/main/java/net/spals/appbuilder/keystore/core/PasswordKeyStorePlugin.java
@@ -1,0 +1,96 @@
+package net.spals.appbuilder.keystore.core;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.inject.Inject;
+import com.netflix.governator.annotations.Configuration;
+import com.typesafe.config.Config;
+import net.spals.appbuilder.annotations.service.AutoBindInMap;
+import org.bouncycastle.jce.provider.BouncyCastleProvider;
+import org.jasypt.encryption.pbe.PBEByteEncryptor;
+import org.jasypt.encryption.pbe.PBEStringEncryptor;
+import org.jasypt.encryption.pbe.PooledPBEByteEncryptor;
+import org.jasypt.encryption.pbe.PooledPBEStringEncryptor;
+
+import javax.annotation.PostConstruct;
+
+/**
+ * A {@link KeyStorePlugin} which stores a single password
+ * that is used for Password Based Encryption.
+ * <p>
+ * The {@link PasswordKeyStorePlugin} is a very simple
+ * {@link KeyStorePlugin} implementation which requires
+ * minimal setup but possesses the highest risk.
+ *
+ * @author tkral
+ */
+@AutoBindInMap(baseClass = KeyStorePlugin.class, key = "password")
+class PasswordKeyStorePlugin implements KeyStorePlugin {
+
+    static KeyStore createPasswordKeyStore(final Config serviceConfig) {
+        final PasswordKeyStorePlugin keyStore = new PasswordKeyStorePlugin();
+        keyStore.createEncryptors(serviceConfig.getString("keyStore.password.pwd"));
+
+        return keyStore;
+    }
+
+    @Configuration("keyStore.password.pwd")
+    @VisibleForTesting
+    volatile String password = null;
+
+    private PBEByteEncryptor byteEncryptor;
+    private PBEStringEncryptor stringEncryptor;
+
+    @Inject
+    PasswordKeyStorePlugin() {  }
+
+    @PostConstruct
+    @VisibleForTesting
+    void postConstruct() {
+        createEncryptors(password);
+    }
+
+    @VisibleForTesting
+    void createEncryptors(String password) {
+        if (password == null) {
+            throw new RuntimeException();
+        }
+
+        final PooledPBEByteEncryptor pooledPBEByteEncryptor =
+            new PooledPBEByteEncryptor();
+        pooledPBEByteEncryptor.setProvider(new BouncyCastleProvider());
+        pooledPBEByteEncryptor.setPasswordCharArray(password.toCharArray());
+        pooledPBEByteEncryptor.setPoolSize(Runtime.getRuntime().availableProcessors());
+        this.byteEncryptor = pooledPBEByteEncryptor;
+
+        final PooledPBEStringEncryptor pooledStringEncryptor =
+            new PooledPBEStringEncryptor();
+        pooledStringEncryptor.setProvider(new BouncyCastleProvider());
+        pooledStringEncryptor.setPasswordCharArray(password.toCharArray());
+        pooledStringEncryptor.setPoolSize(Runtime.getRuntime().availableProcessors());
+        this.stringEncryptor = pooledStringEncryptor;
+
+        // Dereference the password so it will get garbage collected and moved
+        // out of memory as an immutable String.
+        this.password = null;
+    }
+
+    @Override
+    public String decrypt(final String encryptedString) {
+        return stringEncryptor.decrypt(encryptedString);
+    }
+
+    @Override
+    public byte[] decryptBytes(final byte[] encryptedBytes) {
+        return byteEncryptor.decrypt(encryptedBytes);
+    }
+
+    @Override
+    public String encrypt(final String unencryptedString) {
+        return stringEncryptor.encrypt(unencryptedString);
+    }
+
+    @Override
+    public byte[] encryptBytes(final byte[] unencryptedBytes) {
+        return byteEncryptor.encrypt(unencryptedBytes);
+    }
+}

--- a/keystore-core/src/main/java/net/spals/appbuilder/keystore/core/PasswordKeyStorePlugin.java
+++ b/keystore-core/src/main/java/net/spals/appbuilder/keystore/core/PasswordKeyStorePlugin.java
@@ -74,21 +74,33 @@ class PasswordKeyStorePlugin implements KeyStorePlugin {
         this.password = null;
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public String decrypt(final String encryptedString) {
         return stringEncryptor.decrypt(encryptedString);
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public byte[] decryptBytes(final byte[] encryptedBytes) {
         return byteEncryptor.decrypt(encryptedBytes);
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public String encrypt(final String unencryptedString) {
         return stringEncryptor.encrypt(unencryptedString);
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public byte[] encryptBytes(final byte[] unencryptedBytes) {
         return byteEncryptor.encrypt(unencryptedBytes);

--- a/pom.xml
+++ b/pom.xml
@@ -46,6 +46,7 @@
         <ascii-graphs.version>0.0.7</ascii-graphs.version>
         <aws-java-sdk.version>1.11.93</aws-java-sdk.version>
         <bcel.version>6.0</bcel.version>
+        <bouncycastle.version>1.58</bouncycastle.version>
         <cassandra-driver.version>3.2.0</cassandra-driver.version>
         <chill.version>0.9.2</chill.version>
         <dropwizard.version>1.1.0</dropwizard.version>
@@ -59,6 +60,7 @@
         <guava.version>19.0</guava.version>
         <!-- NOTE: Must match what's available in governator.version -->
         <hibernate.version>5.3.4.Final</hibernate.version>
+        <jasypt.version>1.9.2</jasypt.version>
         <!-- NOTE: Must match what's available in governator.version -->
         <javax.el>3.0.0</javax.el>
         <javax.servlet-api.version>3.1.0</javax.servlet-api.version>
@@ -106,6 +108,8 @@
         <module>filestore-s3-test</module>
         <module>graph</module>
         <module>graph-test</module>
+        <module>keystore-core</module>
+        <module>keystore-core-test</module>
         <module>mapstore-cassandra</module>
         <module>mapstore-cassandra-test</module>
         <module>mapstore-core</module>
@@ -429,6 +433,17 @@
             </dependency>
             <dependency>
                 <groupId>net.spals.appbuilder</groupId>
+                <artifactId>spals-appbuilder-keystore-core</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>net.spals.appbuilder</groupId>
+                <artifactId>spals-appbuilder-keystore-core-test</artifactId>
+                <version>${project.version}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>net.spals.appbuilder</groupId>
                 <artifactId>spals-appbuilder-mapstore-core</artifactId>
                 <version>${project.version}</version>
             </dependency>
@@ -591,6 +606,11 @@
                 <version>${kafka-clients.version}</version>
             </dependency>
             <dependency>
+                <groupId>org.bouncycastle</groupId>
+                <artifactId>bcprov-jdk15on</artifactId>
+                <version>${bouncycastle.version}</version>
+            </dependency>
+            <dependency>
                 <groupId>org.glassfish</groupId>
                 <artifactId>javax.el</artifactId>
                 <version>${javax.el}</version>
@@ -599,6 +619,11 @@
                 <groupId>org.hibernate</groupId>
                 <artifactId>hibernate-validator</artifactId>
                 <version>${hibernate.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.jasypt</groupId>
+                <artifactId>jasypt</artifactId>
+                <version>${jasypt.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.jgrapht</groupId>

--- a/reporting/pom.xml
+++ b/reporting/pom.xml
@@ -64,6 +64,14 @@
         </dependency>
         <dependency>
             <groupId>net.spals.appbuilder</groupId>
+            <artifactId>spals-appbuilder-keystore-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>net.spals.appbuilder</groupId>
+            <artifactId>spals-appbuilder-keystore-core-test</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>net.spals.appbuilder</groupId>
             <artifactId>spals-appbuilder-mapstore-core</artifactId>
         </dependency>
         <dependency>


### PR DESCRIPTION
@thespags @john-brock 

Adding support for a new type of service: `KeyStore`. `KeyStore`s allow for bi-directional encryption (i.e. encrypting and decrypting values). I've provided a default implementation called `PasswordKeyStore` which is a port of @thespags 's work in Drunkr based on jasypt.

In the future, we can consider adding other `KeyStore` implementations. Two possibilities that come to mind are: [JVM KeyStore](https://www.digitalocean.com/community/tutorials/java-keytool-essentials-working-with-java-keystores) and [the Key Management Service in AWS](https://aws.amazon.com/kms/). But I imagine that the password-based one will get us pretty far.

`KeyStore` is an injectable micro-service just like any other that you can use anywhere in your application:
```java
@AutoBindSingleton
class MyServiceImpl implements MyService {

    private final KeyStore keyStore;

    @Inject
    MyServiceImpl(final KeyStore keyStore) {
        this.keyStore = keyStore;
    }

    ...
    keyStore.encrypt(string);
    ...
}
```
The `KeyStore` is configured in a similar way to other services:
```
keyStore.system="password"

keyStore.password.pwd=${DRUNKR_MASTER_PASSWORD}
```

The `KeyStore` service is also made available to the configuration management in AppBuilder. Encrypted configuration follows the `jasypt` model of `ENC(encrypted_value)`. When AppBuilder encounters this configuration, it will use the configured `KeyStore` to decrypt the value for configuration injection.