### PR TITLE
Use Guava cache in DefaultServiceExecutorFactory with stop invariant

### DIFF
--- a/executor-core-test/src/test/java/net/spals/appbuilder/executor/core/DefaultExecutorServiceFactoryTest.java
+++ b/executor-core-test/src/test/java/net/spals/appbuilder/executor/core/DefaultExecutorServiceFactoryTest.java
@@ -1,22 +1,20 @@
 package net.spals.appbuilder.executor.core;
 
-import static com.googlecode.catchexception.CatchException.catchException;
-import static com.googlecode.catchexception.CatchException.caughtException;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.*;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.*;
+import io.opentracing.contrib.concurrent.TracedExecutorService;
+import io.opentracing.mock.MockTracer;
+import net.spals.appbuilder.executor.core.ExecutorServiceFactory.Key;
+import org.testng.annotations.Test;
 
 import java.lang.reflect.Field;
 import java.util.Optional;
 import java.util.concurrent.*;
 
-import io.opentracing.contrib.concurrent.TracedExecutorService;
-import io.opentracing.mock.MockTracer;
-import org.testng.annotations.Test;
-
-import net.spals.appbuilder.executor.core.ExecutorServiceFactory.Key;
+import static com.googlecode.catchexception.CatchException.catchException;
+import static com.googlecode.catchexception.CatchException.caughtException;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 
 /**
  * Unit tests for {@link DefaultExecutorServiceFactory}
@@ -35,6 +33,7 @@ public class DefaultExecutorServiceFactoryTest {
     @Test
     public void testCreateFixedThreadPool() {
         final DefaultExecutorServiceFactory executorServiceFactory = new DefaultExecutorServiceFactory(new MockTracer());
+        executorServiceFactory.setupCache();
 
         final ExecutorService executorService = executorServiceFactory.createFixedThreadPool(2, KEY_1);
         assertThat(executorService, instanceOf(TracedExecutorService.class));
@@ -52,6 +51,7 @@ public class DefaultExecutorServiceFactoryTest {
     @Test
     public void testCreateCachedThreadPool() {
         final DefaultExecutorServiceFactory executorServiceFactory = new DefaultExecutorServiceFactory(new MockTracer());
+        executorServiceFactory.setupCache();
 
         final ExecutorService executorService = executorServiceFactory.createCachedThreadPool(KEY_1);
         assertThat(executorService, instanceOf(TracedExecutorService.class));
@@ -69,6 +69,7 @@ public class DefaultExecutorServiceFactoryTest {
     @Test
     public void testCreateSingleThreadExecutor() {
         final DefaultExecutorServiceFactory executorServiceFactory = new DefaultExecutorServiceFactory(new MockTracer());
+        executorServiceFactory.setupCache();
 
         final ExecutorService executorService = executorServiceFactory.createSingleThreadExecutor(KEY_1);
         assertThat(executorService, instanceOf(TracedExecutorService.class));
@@ -83,6 +84,7 @@ public class DefaultExecutorServiceFactoryTest {
     @Test
     public void testCreateSingleThreadScheduledExecutor() {
         final DefaultExecutorServiceFactory executorServiceFactory = new DefaultExecutorServiceFactory(new MockTracer());
+        executorServiceFactory.setupCache();
 
         final ScheduledExecutorService scheduledExecutorService =
             executorServiceFactory.createSingleThreadScheduledExecutor(KEY_1);
@@ -98,6 +100,7 @@ public class DefaultExecutorServiceFactoryTest {
     @Test
     public void testCreateScheduledThreadPool() {
         final DefaultExecutorServiceFactory executorServiceFactory = new DefaultExecutorServiceFactory(new MockTracer());
+        executorServiceFactory.setupCache();
 
         final ScheduledExecutorService scheduledExecutorService =
             executorServiceFactory.createScheduledThreadPool(2, KEY_1);
@@ -116,6 +119,7 @@ public class DefaultExecutorServiceFactoryTest {
     @Test
     public void testRegisterFixedThreadPool() {
         final DefaultExecutorServiceFactory executorServiceFactory = new DefaultExecutorServiceFactory(new MockTracer());
+        executorServiceFactory.setupCache();
 
         final ExecutorService executorService = executorServiceFactory.createFixedThreadPool(2, KEY_1);
 
@@ -128,6 +132,7 @@ public class DefaultExecutorServiceFactoryTest {
     @Test
     public void testRegisterCachedThreadPool() {
         final DefaultExecutorServiceFactory executorServiceFactory = new DefaultExecutorServiceFactory(new MockTracer());
+        executorServiceFactory.setupCache();
 
         final ExecutorService executorService = executorServiceFactory.createCachedThreadPool(KEY_1);
 
@@ -140,6 +145,7 @@ public class DefaultExecutorServiceFactoryTest {
     @Test
     public void testRegisterSingleThreadExecutor() {
         final DefaultExecutorServiceFactory executorServiceFactory = new DefaultExecutorServiceFactory(new MockTracer());
+        executorServiceFactory.setupCache();
 
         final ExecutorService executorService = executorServiceFactory.createSingleThreadExecutor(KEY_1);
 
@@ -152,6 +158,7 @@ public class DefaultExecutorServiceFactoryTest {
     @Test
     public void testRegisterSingleThreadScheduledExecutor() {
         final DefaultExecutorServiceFactory executorServiceFactory = new DefaultExecutorServiceFactory(new MockTracer());
+        executorServiceFactory.setupCache();
 
         final ScheduledExecutorService scheduledExecutorService =
             executorServiceFactory.createSingleThreadScheduledExecutor(KEY_1);
@@ -165,6 +172,7 @@ public class DefaultExecutorServiceFactoryTest {
     @Test
     public void testRegisterScheduledThreadPool() {
         final DefaultExecutorServiceFactory executorServiceFactory = new DefaultExecutorServiceFactory(new MockTracer());
+        executorServiceFactory.setupCache();
 
         final ScheduledExecutorService scheduledExecutorService =
             executorServiceFactory.createScheduledThreadPool(2, KEY_1);
@@ -178,6 +186,8 @@ public class DefaultExecutorServiceFactoryTest {
     @Test
     public void testStopAll() {
         final DefaultExecutorServiceFactory executorServiceFactory = new DefaultExecutorServiceFactory(new MockTracer());
+        executorServiceFactory.setupCache();
+
         final ExecutorService executorService1 = mock(ExecutorService.class);
         executorServiceFactory.getExecutorServices().put(KEY_1, executorService1);
         final ExecutorService executorService2 = mock(ExecutorService.class);
@@ -192,6 +202,8 @@ public class DefaultExecutorServiceFactoryTest {
     @Test
     public void testStop() {
         final DefaultExecutorServiceFactory executorServiceFactory = new DefaultExecutorServiceFactory(new MockTracer());
+        executorServiceFactory.setupCache();
+
         final ExecutorService executorService = mock(ExecutorService.class);
         executorServiceFactory.getExecutorServices().put(KEY_1, executorService);
 
@@ -201,7 +213,8 @@ public class DefaultExecutorServiceFactoryTest {
 
     @Test
     public void testStopMissingKey() {
-        final DefaultExecutorServiceFactory executorServiceFactory = spy(new DefaultExecutorServiceFactory(new MockTracer()));
+        final DefaultExecutorServiceFactory executorServiceFactory = new DefaultExecutorServiceFactory(new MockTracer());
+        executorServiceFactory.setupCache();
 
         catchException(() -> executorServiceFactory.stop(KEY_1));
         assertThat(caughtException(), nullValue());
@@ -209,18 +222,20 @@ public class DefaultExecutorServiceFactoryTest {
 
     @Test
     public void testGetWith() {
-        final DefaultExecutorServiceFactory executorServiceFactory = spy(new DefaultExecutorServiceFactory(new MockTracer()));
+        final DefaultExecutorServiceFactory executorServiceFactory = new DefaultExecutorServiceFactory(new MockTracer());
+        executorServiceFactory.setupCache();
+
         final ExecutorService executorService = mock(ExecutorService.class);
         executorServiceFactory.getExecutorServices().put(KEY_1, executorService);
 
         final Optional<ExecutorService> actual = executorServiceFactory.get(KEY_1);
-
         assertThat(actual, is(Optional.of(executorService)));
     }
 
     @Test
     public void testGetMissingKey() {
-        final DefaultExecutorServiceFactory executorServiceFactory = spy(new DefaultExecutorServiceFactory(new MockTracer()));
+        final DefaultExecutorServiceFactory executorServiceFactory = new DefaultExecutorServiceFactory(new MockTracer());
+        executorServiceFactory.setupCache();
 
         final Optional<ExecutorService> actual = executorServiceFactory.get(KEY_1);
 

--- a/executor-core-test/src/test/java/net/spals/appbuilder/executor/core/DefaultExecutorServiceFactoryTest.java
+++ b/executor-core-test/src/test/java/net/spals/appbuilder/executor/core/DefaultExecutorServiceFactoryTest.java
@@ -1,5 +1,7 @@
 package net.spals.appbuilder.executor.core;
 
+import static com.googlecode.catchexception.CatchException.catchException;
+import static com.googlecode.catchexception.CatchException.caughtException;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
 import static org.mockito.ArgumentMatchers.any;
@@ -175,7 +177,7 @@ public class DefaultExecutorServiceFactoryTest {
 
     @Test
     public void testStopAll() {
-        final DefaultExecutorServiceFactory executorServiceFactory = spy(new DefaultExecutorServiceFactory(new MockTracer()));
+        final DefaultExecutorServiceFactory executorServiceFactory = new DefaultExecutorServiceFactory(new MockTracer());
         final ExecutorService executorService1 = mock(ExecutorService.class);
         executorServiceFactory.getExecutorServices().put(KEY_1, executorService1);
         final ExecutorService executorService2 = mock(ExecutorService.class);
@@ -183,43 +185,26 @@ public class DefaultExecutorServiceFactoryTest {
 
         executorServiceFactory.stopAll();
 
-        verify(executorServiceFactory).stopExecutorService(eq(KEY_1), eq(executorService1));
-        verify(executorServiceFactory).stopExecutorService(eq(KEY_2), eq(executorService2));
+        verify(executorService1).shutdown();
+        verify(executorService2).shutdown();
     }
 
     @Test
     public void testStop() {
-        final DefaultExecutorServiceFactory executorServiceFactory = spy(new DefaultExecutorServiceFactory(new MockTracer()));
+        final DefaultExecutorServiceFactory executorServiceFactory = new DefaultExecutorServiceFactory(new MockTracer());
         final ExecutorService executorService = mock(ExecutorService.class);
         executorServiceFactory.getExecutorServices().put(KEY_1, executorService);
 
         executorServiceFactory.stop(KEY_1);
-
-        // Verify that we called the stopExecutorService with the correct parameters
-        verify(executorServiceFactory).stopExecutorService(eq(KEY_1), eq(executorService));
-    }
-
-    @Test
-    public void testStopAlreadyStopped() {
-        final DefaultExecutorServiceFactory executorServiceFactory = spy(new DefaultExecutorServiceFactory(new MockTracer()));
-        final ExecutorService executorService = mock(ExecutorService.class);
-        when(executorService.isShutdown()).thenReturn(true);
-        executorServiceFactory.getExecutorServices().put(KEY_1, executorService);
-
-        final Optional<Boolean> stopped = executorServiceFactory.stop(KEY_1);
-
-        assertThat(stopped, is(Optional.of(true)));
-        verify(executorServiceFactory).stopExecutorService(eq(KEY_1), eq(executorService));
+        verify(executorService).shutdown();
     }
 
     @Test
     public void testStopMissingKey() {
         final DefaultExecutorServiceFactory executorServiceFactory = spy(new DefaultExecutorServiceFactory(new MockTracer()));
 
-        final Optional<Boolean> stopped = executorServiceFactory.stop(KEY_1);
-
-        assertThat(stopped, is(Optional.empty()));
-        verify(executorServiceFactory, never()).stopExecutorService(any(Key.class), any(ExecutorService.class));
+        catchException(() -> executorServiceFactory.stop(KEY_1));
+        assertThat(caughtException(), nullValue());
     }
 
     @Test

--- a/executor-core/pom.xml
+++ b/executor-core/pom.xml
@@ -19,6 +19,10 @@
             <artifactId>logback-classic</artifactId>
         </dependency>
         <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+        </dependency>
+        <dependency>
             <groupId>com.netflix.governator</groupId>
             <artifactId>governator-api</artifactId>
         </dependency>

--- a/executor-core/src/main/java/net/spals/appbuilder/executor/core/DefaultExecutorServiceFactory.java
+++ b/executor-core/src/main/java/net/spals/appbuilder/executor/core/DefaultExecutorServiceFactory.java
@@ -1,6 +1,7 @@
 package net.spals.appbuilder.executor.core;
 
 import javax.annotation.Nonnull;
+import javax.annotation.PostConstruct;
 import javax.annotation.PreDestroy;
 import java.util.*;
 import java.util.concurrent.*;
@@ -32,7 +33,7 @@ class DefaultExecutorServiceFactory implements ExecutorServiceFactory {
 
     private static final Collector<CharSequence, ?, String> JOINING = Collectors.joining(",", "[", "]");
 
-    private final Cache<Key, ExecutorService> executorServices;
+    private Cache<Key, ExecutorService> executorServices;
     private final Tracer tracer;
 
     @Configuration("executorService.registry.shutdown")
@@ -42,10 +43,15 @@ class DefaultExecutorServiceFactory implements ExecutorServiceFactory {
 
     @Inject
     DefaultExecutorServiceFactory(final Tracer tracer) {
+        this.tracer = tracer;
+    }
+
+    @PostConstruct
+    @VisibleForTesting
+    void setupCache() {
         this.executorServices = CacheBuilder.<Key, ExecutorService>newBuilder()
             .removalListener(new ExecutorServiceRemovelListener(shutdown, shutdownUnit))
             .build();
-        this.tracer = tracer;
     }
 
     @Override

--- a/executor-core/src/main/java/net/spals/appbuilder/executor/core/DefaultExecutorServiceFactory.java
+++ b/executor-core/src/main/java/net/spals/appbuilder/executor/core/DefaultExecutorServiceFactory.java
@@ -8,6 +8,10 @@ import java.util.stream.Collector;
 import java.util.stream.Collectors;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.cache.Cache;
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.RemovalListener;
+import com.google.common.cache.RemovalNotification;
 import com.google.inject.Inject;
 
 import com.netflix.governator.annotations.Configuration;
@@ -27,8 +31,10 @@ import net.spals.appbuilder.annotations.service.AutoBindSingleton;
 class DefaultExecutorServiceFactory implements ExecutorServiceFactory {
 
     private static final Collector<CharSequence, ?, String> JOINING = Collectors.joining(",", "[", "]");
-    private final Map<Key, ExecutorService> executorServices = new HashMap<>();
+
+    private final Cache<Key, ExecutorService> executorServices;
     private final Tracer tracer;
+
     @Configuration("executorService.registry.shutdown")
     private volatile Long shutdown = 1000L;
     @Configuration("executorService.registry.shutdownUnit")
@@ -36,7 +42,21 @@ class DefaultExecutorServiceFactory implements ExecutorServiceFactory {
 
     @Inject
     DefaultExecutorServiceFactory(final Tracer tracer) {
+        this.executorServices = CacheBuilder.<Key, ExecutorService>newBuilder()
+            .removalListener(new ExecutorServiceRemovelListener(shutdown, shutdownUnit))
+            .build();
         this.tracer = tracer;
+    }
+
+    @Override
+    public ExecutorService createCachedThreadPool(@Nonnull final Key key) {
+        final ExecutorService delegate = Executors.newCachedThreadPool();
+
+        final ExecutorService executorService = decorateExecutorService(delegate);
+        executorServices.put(key, executorService);
+        getExecutorServiceLogger(key).info("Created CachedThreadPool executor service");
+
+        return executorService;
     }
 
     @Override
@@ -54,17 +74,6 @@ class DefaultExecutorServiceFactory implements ExecutorServiceFactory {
     }
 
     @Override
-    public ExecutorService createCachedThreadPool(@Nonnull final Key key) {
-        final ExecutorService delegate = Executors.newCachedThreadPool();
-
-        final ExecutorService executorService = decorateExecutorService(delegate);
-        executorServices.put(key, executorService);
-        getExecutorServiceLogger(key).info("Created CachedThreadPool executor service");
-
-        return executorService;
-    }
-
-    @Override
     public ExecutorService createSingleThreadExecutor(@Nonnull final Key key) {
         final ExecutorService delegate = Executors.newSingleThreadExecutor();
 
@@ -73,17 +82,6 @@ class DefaultExecutorServiceFactory implements ExecutorServiceFactory {
         getExecutorServiceLogger(key).info("Created SingleThreadExecutor executor service");
 
         return executorService;
-    }
-
-    @Override
-    public ScheduledExecutorService createSingleThreadScheduledExecutor(@Nonnull final Key key) {
-        final ScheduledExecutorService delegate = Executors.newSingleThreadScheduledExecutor();
-
-        final ScheduledExecutorService scheduledExecutorService = decorateScheduledExecutorService(delegate);
-        executorServices.put(key, scheduledExecutorService);
-        getExecutorServiceLogger(key).info("Created SingleThreadScheduledExecutor scheduled executor service");
-
-        return scheduledExecutorService;
     }
 
     @Override
@@ -101,13 +99,24 @@ class DefaultExecutorServiceFactory implements ExecutorServiceFactory {
     }
 
     @Override
-    public Optional<Boolean> stop(@Nonnull final Key key) {
-        return get(key).map(executorService -> stopExecutorService(key, executorService));
+    public ScheduledExecutorService createSingleThreadScheduledExecutor(@Nonnull final Key key) {
+        final ScheduledExecutorService delegate = Executors.newSingleThreadScheduledExecutor();
+
+        final ScheduledExecutorService scheduledExecutorService = decorateScheduledExecutorService(delegate);
+        executorServices.put(key, scheduledExecutorService);
+        getExecutorServiceLogger(key).info("Created SingleThreadScheduledExecutor scheduled executor service");
+
+        return scheduledExecutorService;
     }
 
     @Override
     public Optional<ExecutorService> get(@Nonnull final Key key) {
-        return Optional.ofNullable(executorServices.get(key));
+        return Optional.ofNullable(executorServices.getIfPresent(key));
+    }
+
+    @Override
+    public void stop(@Nonnull final Key key) {
+        get(key).ifPresent(executorService -> executorServices.invalidate(key));
     }
 
     private ExecutorService decorateExecutorService(final ExecutorService delegate) {
@@ -120,14 +129,14 @@ class DefaultExecutorServiceFactory implements ExecutorServiceFactory {
         return new TracedScheduledExecutorService(delegate, tracer);
     }
 
-    private Logger getExecutorServiceLogger(final Key key) {
+    private static Logger getExecutorServiceLogger(final Key key) {
         final String loggerName = key.getParentClass().getName() + key.getTags().stream().collect(JOINING);
         return LoggerFactory.getLogger(loggerName);
     }
 
     @VisibleForTesting
     Map<Key, ExecutorService> getExecutorServices() {
-        return executorServices;
+        return executorServices.asMap();
     }
 
     /**
@@ -135,44 +144,55 @@ class DefaultExecutorServiceFactory implements ExecutorServiceFactory {
      */
     @PreDestroy
     public synchronized void stopAll() {
-        // TODO TPK: Is it OK that all executor service shutdowns happen sequentially?
-        executorServices.forEach(this::stopExecutorService);
+        executorServices.invalidateAll();
     }
 
-    @VisibleForTesting
-    boolean stopExecutorService(
-        @Nonnull final Key key,
-        @Nonnull final ExecutorService executorService
-    ) {
-        if (executorService.isShutdown()) {
-            return true;
+
+    private static class ExecutorServiceRemovelListener implements RemovalListener<Key, ExecutorService> {
+
+        private final long shutdown;
+        private final TimeUnit shutdownUnit;
+
+        private ExecutorServiceRemovelListener(
+            final long shutdown,
+            final TimeUnit shutdownUnit
+        ) {
+            this.shutdown = shutdown;
+            this.shutdownUnit = shutdownUnit;
         }
 
-        final Logger executorServiceLogger = getExecutorServiceLogger(key);
-        executorServiceLogger.info(
-            "Shutting down ExecutorService for " + key.getParentClass().getSimpleName() +
-                "(" + key.getTags() + ")"
-        );
-        // See https://docs.oracle.com/javase/7/docs/api/java/util/concurrent/ExecutorService.html
-        executorService.shutdown(); // Disable new tasks from being submitted
+        @Override
+        public void onRemoval(final RemovalNotification<Key, ExecutorService> notification) {
+            final Key key = notification.getKey();
+            final ExecutorService executorService = notification.getValue();
 
-        try {
-            // Wait a while for existing tasks to terminate
-            if (!executorService.awaitTermination(shutdown, shutdownUnit)) {
-                executorService.shutdownNow(); // Cancel currently executing tasks
-                // Wait a while for tasks to respond to being cancelled
-                if (!executorService.awaitTermination(shutdown, shutdownUnit)) {
-                    executorServiceLogger.warn("Timed out waiting for ExecutorService to terminate.");
-                    return false;
-                }
+            if (executorService.isShutdown()) {
+                return;
             }
-            return true;
-        } catch (final InterruptedException e) {
-            // (Re-)Cancel if current thread also interrupted
-            executorService.shutdownNow();
-            Thread.currentThread().interrupt(); // Preserve interrupt status
-            executorServiceLogger.warn("Interrupted during shutdown of ExecutorService.");
-            return false;
+
+            final Logger executorServiceLogger = getExecutorServiceLogger(key);
+            executorServiceLogger.info(
+                "Shutting down ExecutorService for " + key.getParentClass().getSimpleName() +
+                    "(" + key.getTags() + ")"
+            );
+            // See https://docs.oracle.com/javase/7/docs/api/java/util/concurrent/ExecutorService.html
+            executorService.shutdown(); // Disable new tasks from being submitted
+
+            try {
+                // Wait a while for existing tasks to terminate
+                if (!executorService.awaitTermination(shutdown, shutdownUnit)) {
+                    executorService.shutdownNow(); // Cancel currently executing tasks
+                    // Wait a while for tasks to respond to being cancelled
+                    if (!executorService.awaitTermination(shutdown, shutdownUnit)) {
+                        executorServiceLogger.warn("Timed out waiting for ExecutorService to terminate.");
+                    }
+                }
+            } catch (final InterruptedException e) {
+                // (Re-)Cancel if current thread also interrupted
+                executorService.shutdownNow();
+                Thread.currentThread().interrupt(); // Preserve interrupt status
+                executorServiceLogger.warn("Interrupted during shutdown of ExecutorService.");
+            }
         }
     }
 }

--- a/executor-core/src/main/java/net/spals/appbuilder/executor/core/ExecutorServiceFactory.java
+++ b/executor-core/src/main/java/net/spals/appbuilder/executor/core/ExecutorServiceFactory.java
@@ -12,15 +12,23 @@ import java.util.concurrent.ScheduledExecutorService;
  */
 public interface ExecutorServiceFactory {
 
-    ExecutorService createFixedThreadPool(int nThreads, Key key);
-
     ExecutorService createCachedThreadPool(Key key);
+
+    ExecutorService createFixedThreadPool(int nThreads, Key key);
 
     ExecutorService createSingleThreadExecutor(Key key);
 
+    ScheduledExecutorService createScheduledThreadPool(int nThreads, Key key);
+
     ScheduledExecutorService createSingleThreadScheduledExecutor(Key key);
 
-    ScheduledExecutorService createScheduledThreadPool(int nThreads, Key key);
+    /**
+     * Gets the executor of the given key if it exists. If an executor does NOT exist, then returns {@link Optional#empty()}.
+     *
+     * @param key key of the executor
+     * @return an executor if it exists otherwise empty
+     */
+    Optional<ExecutorService> get(Key key);
 
     /**
      * Stops the executor of the given key. If the key exists, then shutdown the executor returning an optional of true
@@ -31,17 +39,8 @@ public interface ExecutorServiceFactory {
      * </p>
      *
      * @param key key of the executor
-     * @return true if the key exists and the executor is now stopped, false if it exists but stop logic failed, otherwise empty
      */
-    Optional<Boolean> stop(Key key);
-
-    /**
-     * Gets the executor of the given key if it exists. If an executor does NOT exist, then returns {@link Optional#empty()}.
-     *
-     * @param key key of the executor
-     * @return an executor if it exists otherwise empty
-     */
-    Optional<ExecutorService> get(Key key);
+    void stop(Key key);
 
     @FreeBuilder
     interface Key {


### PR DESCRIPTION
@thespags @john-brock 

Small change to the implementation of `DefaultServiceExecutorFactory`. Instead of using a hash map as the internal storage mechanism, I'm switching to a Guava cache which allows for a `RemovalListener` that I use to stop an executor service as soon as it's removed from the cache. Thus we create the invariant that if the executor service is in the cache, it is running, otherwise it is stopped.

I believe this will solve @thespags 's issue with duplicate executors running for Drunkr users. If they start a second job, it will simply replace the first job in the cache and we'll shut it down.