### PR TITLE
Remove BouncyCastle dependency from PasswordKeyStorePlugin

### DIFF
--- a/keystore-core/pom.xml
+++ b/keystore-core/pom.xml
@@ -35,10 +35,6 @@
             <artifactId>spals-appbuilder-annotations</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.bouncycastle</groupId>
-            <artifactId>bcprov-jdk15on</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.jasypt</groupId>
             <artifactId>jasypt</artifactId>
         </dependency>

--- a/keystore-core/src/main/java/net/spals/appbuilder/keystore/core/PasswordKeyStorePlugin.java
+++ b/keystore-core/src/main/java/net/spals/appbuilder/keystore/core/PasswordKeyStorePlugin.java
@@ -5,7 +5,6 @@ import com.google.inject.Inject;
 import com.netflix.governator.annotations.Configuration;
 import com.typesafe.config.Config;
 import net.spals.appbuilder.annotations.service.AutoBindInMap;
-import org.bouncycastle.jce.provider.BouncyCastleProvider;
 import org.jasypt.encryption.pbe.PBEByteEncryptor;
 import org.jasypt.encryption.pbe.PBEStringEncryptor;
 import org.jasypt.encryption.pbe.PooledPBEByteEncryptor;
@@ -21,6 +20,15 @@ import javax.validation.ValidationException;
  * The {@link PasswordKeyStorePlugin} is a very simple
  * {@link KeyStorePlugin} implementation which requires
  * minimal setup but possesses the highest risk.
+ * <p>
+ * Note that this implementation uses the default JVM
+ * security provider. This means that it will work out-of-the-box
+ * without extra work on the part of the application developer
+ * (e.g. installing the Java Cryptography Extension). But
+ * this also means that this provides only low end security.
+ * <p>
+ * Applications which have more serious security concerns
+ * should consider using a different implementation.
  *
  * @author tkral
  */
@@ -60,14 +68,12 @@ class PasswordKeyStorePlugin implements KeyStorePlugin {
 
         final PooledPBEByteEncryptor pooledPBEByteEncryptor =
             new PooledPBEByteEncryptor();
-        pooledPBEByteEncryptor.setProvider(new BouncyCastleProvider());
         pooledPBEByteEncryptor.setPasswordCharArray(password.toCharArray());
         pooledPBEByteEncryptor.setPoolSize(Runtime.getRuntime().availableProcessors());
         this.byteEncryptor = pooledPBEByteEncryptor;
 
         final PooledPBEStringEncryptor pooledStringEncryptor =
             new PooledPBEStringEncryptor();
-        pooledStringEncryptor.setProvider(new BouncyCastleProvider());
         pooledStringEncryptor.setPasswordCharArray(password.toCharArray());
         pooledStringEncryptor.setPoolSize(Runtime.getRuntime().availableProcessors());
         this.stringEncryptor = pooledStringEncryptor;

--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,6 @@
         <ascii-graphs.version>0.0.7</ascii-graphs.version>
         <aws-java-sdk.version>1.11.93</aws-java-sdk.version>
         <bcel.version>6.0</bcel.version>
-        <bouncycastle.version>1.58</bouncycastle.version>
         <cassandra-driver.version>3.2.0</cassandra-driver.version>
         <chill.version>0.9.2</chill.version>
         <dropwizard.version>1.1.0</dropwizard.version>
@@ -604,11 +603,6 @@
                 <groupId>org.apache.kafka</groupId>
                 <artifactId>kafka-clients</artifactId>
                 <version>${kafka-clients.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.bouncycastle</groupId>
-                <artifactId>bcprov-jdk15on</artifactId>
-                <version>${bouncycastle.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.glassfish</groupId>


### PR DESCRIPTION
@thespags @john-brock 

Removing the BouncyCastle dependency from the default KeyStore. This should allow the default KeyStore to work out of the box which is really the functionality that we want. Otherwise, the application developer has to ensure that the Java Cryptography Extension is properly installed.

The downside here is that this removes security robustness, but I think that's OK. Default service implementations are really meant to get you off the ground quickly with application development. And as your needs change, you'll migrate to service plugins. In this case, as security needs change for an application, developers should migrate to a more robust security implementation (which is still a TODO).