### PR TITLE
Add functionality for MapStore indexes

### DIFF
--- a/annotations/src/main/java/net/spals/appbuilder/annotations/service/AutoBindProvider.java
+++ b/annotations/src/main/java/net/spals/appbuilder/annotations/service/AutoBindProvider.java
@@ -21,6 +21,7 @@ public @interface AutoBindProvider {
     Class<? extends Annotation> bindingAnnotation() default AutoBindProvider.class;
 
     enum ProviderScope {
+        LAZY_SINGLETON,
         NONE,
         REQUEST,
         SESSION,

--- a/app-core-test/src/test/java/net/spals/appbuilder/app/core/generic/SampleGenericWorkerAppFTest.java
+++ b/app-core-test/src/test/java/net/spals/appbuilder/app/core/generic/SampleGenericWorkerAppFTest.java
@@ -18,6 +18,8 @@ import net.spals.appbuilder.graph.model.ServiceGraphFormat;
 import net.spals.appbuilder.keystore.core.KeyStore;
 import net.spals.appbuilder.keystore.core.KeyStorePlugin;
 import net.spals.appbuilder.mapstore.core.MapStore;
+import net.spals.appbuilder.mapstore.core.MapStoreIndex;
+import net.spals.appbuilder.mapstore.core.MapStoreIndexPlugin;
 import net.spals.appbuilder.mapstore.core.MapStorePlugin;
 import net.spals.appbuilder.message.core.MessageConsumer;
 import net.spals.appbuilder.message.core.MessageConsumerCallback;
@@ -145,6 +147,19 @@ public class SampleGenericWorkerAppFTest {
             serviceInjector.getInstance(Key.get(mapStorePluginMapKey));
         assertThat(mapStorePluginMap, aMapWithSize(1));
         assertThat(mapStorePluginMap, hasKey("mapDB"));
+    }
+
+    @Test
+    public void testMapStoreIndexInjection() {
+        final Injector serviceInjector = sampleApp.getServiceInjector();
+        assertThat(serviceInjector.getInstance(MapStoreIndex.class), notNullValue());
+
+        final TypeLiteral<Map<String, MapStoreIndexPlugin>> mapStoreIndexPluginMapKey =
+            new TypeLiteral<Map<String, MapStoreIndexPlugin>>(){};
+        final Map<String, MapStoreIndexPlugin> mapStoreIndexPluginMap =
+            serviceInjector.getInstance(Key.get(mapStoreIndexPluginMapKey));
+        assertThat(mapStoreIndexPluginMap, aMapWithSize(1));
+        assertThat(mapStoreIndexPluginMap, hasKey("mapDB"));
     }
 
     @Test

--- a/app-core-test/src/test/java/net/spals/appbuilder/app/core/jaxrs/SampleJaxRsWebAppFTest.java
+++ b/app-core-test/src/test/java/net/spals/appbuilder/app/core/jaxrs/SampleJaxRsWebAppFTest.java
@@ -22,6 +22,8 @@ import net.spals.appbuilder.graph.model.ServiceGraphFormat;
 import net.spals.appbuilder.keystore.core.KeyStore;
 import net.spals.appbuilder.keystore.core.KeyStorePlugin;
 import net.spals.appbuilder.mapstore.core.MapStore;
+import net.spals.appbuilder.mapstore.core.MapStoreIndex;
+import net.spals.appbuilder.mapstore.core.MapStoreIndexPlugin;
 import net.spals.appbuilder.mapstore.core.MapStorePlugin;
 import net.spals.appbuilder.message.core.MessageConsumer;
 import net.spals.appbuilder.message.core.MessageConsumerCallback;
@@ -170,6 +172,19 @@ public class SampleJaxRsWebAppFTest {
             serviceInjector.getInstance(Key.get(mapStorePluginMapKey));
         assertThat(mapStorePluginMap, aMapWithSize(1));
         assertThat(mapStorePluginMap, hasKey("mapDB"));
+    }
+
+    @Test
+    public void testMapStoreIndexInjection() {
+        final Injector serviceInjector = sampleApp.getServiceInjector();
+        assertThat(serviceInjector.getInstance(MapStoreIndex.class), notNullValue());
+
+        final TypeLiteral<Map<String, MapStoreIndexPlugin>> mapStoreIndexPluginMapKey =
+            new TypeLiteral<Map<String, MapStoreIndexPlugin>>(){};
+        final Map<String, MapStoreIndexPlugin> mapStoreIndexPluginMap =
+            serviceInjector.getInstance(Key.get(mapStoreIndexPluginMapKey));
+        assertThat(mapStoreIndexPluginMap, aMapWithSize(1));
+        assertThat(mapStoreIndexPluginMap, hasKey("mapDB"));
     }
 
     @Test

--- a/app-core-test/src/test/java/net/spals/appbuilder/app/core/modules/AutoBindServicesModuleTest.java
+++ b/app-core-test/src/test/java/net/spals/appbuilder/app/core/modules/AutoBindServicesModuleTest.java
@@ -5,6 +5,7 @@ import com.google.inject.*;
 import com.google.inject.binder.AnnotatedBindingBuilder;
 import com.google.inject.binder.ScopedBindingBuilder;
 import com.google.inject.servlet.ServletScopes;
+import com.netflix.governator.guice.lazy.LazySingletonScope;
 import net.spals.appbuilder.annotations.service.AutoBindInMap;
 import net.spals.appbuilder.annotations.service.AutoBindProvider;
 import net.spals.appbuilder.annotations.service.AutoBindSingleton;
@@ -50,6 +51,7 @@ public class AutoBindServicesModuleTest {
     Object[][] autoBindProvidersProvider() {
         return new Object[][] {
                 {MyProviderDefaultScope.class, Scopes.SINGLETON},
+                {MyProviderLazySingletonScope.class, LazySingletonScope.get()},
                 {MyProviderNoScope.class, Scopes.NO_SCOPE},
                 {MyProviderRequestScope.class, ServletScopes.REQUEST},
                 {MyProviderSessionScope.class, ServletScopes.SESSION},
@@ -198,6 +200,14 @@ public class AutoBindServicesModuleTest {
 
     @AutoBindProvider
     private class MyProviderDefaultScope implements Provider<String> {
+        @Override
+        public String get() {
+            return "";
+        }
+    }
+
+    @AutoBindProvider(LAZY_SINGLETON)
+    private class MyProviderLazySingletonScope implements Provider<String> {
         @Override
         public String get() {
             return "";

--- a/app-core/pom.xml
+++ b/app-core/pom.xml
@@ -43,6 +43,10 @@
             <artifactId>governator</artifactId>
         </dependency>
         <dependency>
+            <groupId>com.netflix.governator</groupId>
+            <artifactId>governator-core</artifactId>
+        </dependency>
+        <dependency>
             <groupId>com.typesafe</groupId>
             <artifactId>config</artifactId>
         </dependency>

--- a/app-core/src/main/java/net/spals/appbuilder/app/core/modules/AutoBindServicesModule.java
+++ b/app-core/src/main/java/net/spals/appbuilder/app/core/modules/AutoBindServicesModule.java
@@ -6,6 +6,7 @@ import com.google.inject.assistedinject.FactoryModuleBuilder;
 import com.google.inject.multibindings.MapBinder;
 import com.google.inject.multibindings.Multibinder;
 import com.google.inject.servlet.ServletScopes;
+import com.netflix.governator.guice.lazy.LazySingletonScope;
 import net.spals.appbuilder.annotations.service.*;
 import net.spals.appbuilder.annotations.service.AutoBindProvider.ProviderScope;
 import net.spals.appbuilder.config.service.ServiceScan;
@@ -212,6 +213,7 @@ public abstract class AutoBindServicesModule extends AbstractModule {
     @VisibleForTesting
     Scope mapProviderScope(final ProviderScope providerScope) {
         switch (providerScope) {
+            case LAZY_SINGLETON: return LazySingletonScope.get();
             case NONE: return Scopes.NO_SCOPE;
             case REQUEST: return ServletScopes.REQUEST;
             case SESSION: return ServletScopes.SESSION;

--- a/app-dropwizard-test/src/test/java/net/spals/appbuilder/app/dropwizard/PluginsDropwizardWebAppFTest.java
+++ b/app-dropwizard-test/src/test/java/net/spals/appbuilder/app/dropwizard/PluginsDropwizardWebAppFTest.java
@@ -15,6 +15,8 @@ import net.spals.appbuilder.filestore.core.FileStorePlugin;
 import net.spals.appbuilder.keystore.core.KeyStore;
 import net.spals.appbuilder.keystore.core.KeyStorePlugin;
 import net.spals.appbuilder.mapstore.core.MapStore;
+import net.spals.appbuilder.mapstore.core.MapStoreIndex;
+import net.spals.appbuilder.mapstore.core.MapStoreIndexPlugin;
 import net.spals.appbuilder.mapstore.core.MapStorePlugin;
 import net.spals.appbuilder.message.core.MessageConsumer;
 import net.spals.appbuilder.message.core.MessageProducer;
@@ -95,6 +97,21 @@ public class PluginsDropwizardWebAppFTest {
         assertThat(mapStorePluginMap, hasKey("dynamoDB"));
         assertThat(mapStorePluginMap, hasKey("mapDB"));
         assertThat(mapStorePluginMap, hasKey("mongoDB"));
+    }
+
+    @Test
+    public void testMapStoreIndexInjection() {
+        final Injector serviceInjector = webAppDelegate.getServiceInjector();
+        assertThat(serviceInjector.getInstance(MapStoreIndex.class), notNullValue());
+
+        final TypeLiteral<Map<String, MapStoreIndexPlugin>> mapStoreIndexPluginMapKey =
+            new TypeLiteral<Map<String, MapStoreIndexPlugin>>(){};
+        final Map<String, MapStoreIndexPlugin> mapStoreIndexPluginMap =
+            serviceInjector.getInstance(Key.get(mapStoreIndexPluginMapKey));
+        assertThat(mapStoreIndexPluginMap, aMapWithSize(3));
+        assertThat(mapStoreIndexPluginMap, hasKey("dynamoDB"));
+        assertThat(mapStoreIndexPluginMap, hasKey("mapDB"));
+        assertThat(mapStoreIndexPluginMap, hasKey("mongoDB"));
     }
 
     @Test

--- a/app-dropwizard-test/src/test/java/net/spals/appbuilder/app/dropwizard/SampleDropwizardWebAppFTest.java
+++ b/app-dropwizard-test/src/test/java/net/spals/appbuilder/app/dropwizard/SampleDropwizardWebAppFTest.java
@@ -17,6 +17,8 @@ import net.spals.appbuilder.filestore.core.FileStorePlugin;
 import net.spals.appbuilder.keystore.core.KeyStore;
 import net.spals.appbuilder.keystore.core.KeyStorePlugin;
 import net.spals.appbuilder.mapstore.core.MapStore;
+import net.spals.appbuilder.mapstore.core.MapStoreIndex;
+import net.spals.appbuilder.mapstore.core.MapStoreIndexPlugin;
 import net.spals.appbuilder.mapstore.core.MapStorePlugin;
 import net.spals.appbuilder.message.core.MessageConsumer;
 import net.spals.appbuilder.message.core.MessageConsumerCallback;
@@ -143,6 +145,19 @@ public class SampleDropwizardWebAppFTest {
             serviceInjector.getInstance(Key.get(mapStorePluginMapKey));
         assertThat(mapStorePluginMap, aMapWithSize(1));
         assertThat(mapStorePluginMap, hasKey("mapDB"));
+    }
+
+    @Test
+    public void testMapStoreIndexInjection() {
+        final Injector serviceInjector = webAppDelegate.getServiceInjector();
+        assertThat(serviceInjector.getInstance(MapStoreIndex.class), notNullValue());
+
+        final TypeLiteral<Map<String, MapStoreIndexPlugin>> mapStoreIndexPluginMapKey =
+            new TypeLiteral<Map<String, MapStoreIndexPlugin>>(){};
+        final Map<String, MapStoreIndexPlugin> mapStoreIndexPluginMap =
+            serviceInjector.getInstance(Key.get(mapStoreIndexPluginMapKey));
+        assertThat(mapStoreIndexPluginMap, aMapWithSize(1));
+        assertThat(mapStoreIndexPluginMap, hasKey("mapDB"));
     }
 
     @Test

--- a/app-finatra-test/src/test/scala/net/spals/appbuilder/app/finatra/PluginsFinatraWebAppFTest.scala
+++ b/app-finatra-test/src/test/scala/net/spals/appbuilder/app/finatra/PluginsFinatraWebAppFTest.scala
@@ -7,7 +7,7 @@ import com.twitter.finatra.http.EmbeddedHttpServer
 import net.spals.appbuilder.app.finatra.plugins.PluginsFinatraWebApp
 import net.spals.appbuilder.filestore.core.{FileStore, FileStorePlugin}
 import net.spals.appbuilder.keystore.core.{KeyStore, KeyStorePlugin}
-import net.spals.appbuilder.mapstore.core.{MapStore, MapStorePlugin}
+import net.spals.appbuilder.mapstore.core.{MapStore, MapStoreIndex, MapStoreIndexPlugin, MapStorePlugin}
 import net.spals.appbuilder.message.core.consumer.MessageConsumerPlugin
 import net.spals.appbuilder.message.core.producer.MessageProducerPlugin
 import net.spals.appbuilder.message.core.{MessageConsumer, MessageProducer}
@@ -71,6 +71,18 @@ class PluginsFinatraWebAppFTest {
     assertThat(mapStorePluginMap, hasKey("dynamoDB"))
     assertThat(mapStorePluginMap, hasKey("mapDB"))
     assertThat(mapStorePluginMap, hasKey("mongoDB"))
+  }
+
+  @Test def testMapStoreIndexInjection() {
+    val serviceInjector = pluginsApp.getServiceInjector
+    assertThat(serviceInjector.getInstance(classOf[MapStoreIndex]), notNullValue())
+
+    val mapStoreIndexPluginMapKey = new TypeLiteral[java.util.Map[String, MapStoreIndexPlugin]](){}
+    val mapStoreIndexPluginMap = serviceInjector.getInstance(Key.get(mapStoreIndexPluginMapKey))
+    assertThat(mapStoreIndexPluginMap, Matchers.aMapWithSize[String, MapStoreIndexPlugin](3))
+    assertThat(mapStoreIndexPluginMap, hasKey("dynamoDB"))
+    assertThat(mapStoreIndexPluginMap, hasKey("mapDB"))
+    assertThat(mapStoreIndexPluginMap, hasKey("mongoDB"))
   }
 
   @Test def testCassandraMapStoreInjection() {

--- a/app-finatra-test/src/test/scala/net/spals/appbuilder/app/finatra/SampleFinatraWebAppFTest.scala
+++ b/app-finatra-test/src/test/scala/net/spals/appbuilder/app/finatra/SampleFinatraWebAppFTest.scala
@@ -10,7 +10,7 @@ import net.spals.appbuilder.app.finatra.sample.{SampleFinatraCustomService, Samp
 import net.spals.appbuilder.executor.core.ExecutorServiceFactory
 import net.spals.appbuilder.filestore.core.{FileStore, FileStorePlugin}
 import net.spals.appbuilder.keystore.core.{KeyStore, KeyStorePlugin}
-import net.spals.appbuilder.mapstore.core.{MapStore, MapStorePlugin}
+import net.spals.appbuilder.mapstore.core.{MapStore, MapStoreIndex, MapStoreIndexPlugin, MapStorePlugin}
 import net.spals.appbuilder.message.core.consumer.MessageConsumerPlugin
 import net.spals.appbuilder.message.core.producer.MessageProducerPlugin
 import net.spals.appbuilder.message.core.{MessageConsumer, MessageConsumerCallback, MessageProducer}
@@ -118,6 +118,16 @@ class SampleFinatraWebAppFTest {
     val mapStorePluginMap = serviceInjector.getInstance(Key.get(mapStorePluginMapKey))
     assertThat(mapStorePluginMap, Matchers.aMapWithSize[String, MapStorePlugin](1))
     assertThat(mapStorePluginMap, hasKey("mapDB"))
+  }
+
+  @Test def testMapStoreIndexInjection() {
+    val serviceInjector = sampleApp.getServiceInjector
+    assertThat(serviceInjector.getInstance(classOf[MapStoreIndex]), notNullValue())
+
+    val mapStoreIndexPluginMapKey = new TypeLiteral[java.util.Map[String, MapStoreIndexPlugin]](){}
+    val mapStoreIndexPluginMap = serviceInjector.getInstance(Key.get(mapStoreIndexPluginMapKey))
+    assertThat(mapStoreIndexPluginMap, Matchers.aMapWithSize[String, MapStoreIndexPlugin](1))
+    assertThat(mapStoreIndexPluginMap, hasKey("mapDB"))
   }
 
   @Test def testMessageConsumerInjection() {

--- a/mapstore-cassandra-test/src/test/scala/net/spals/appbuilder/mapstore/cassandra/CassandraMapStorePluginIT.scala
+++ b/mapstore-cassandra-test/src/test/scala/net/spals/appbuilder/mapstore/cassandra/CassandraMapStorePluginIT.scala
@@ -11,7 +11,6 @@ import net.spals.appbuilder.mapstore.core.model.ZeroValueMapRangeKey.all
 import net.spals.appbuilder.mapstore.core.model.{MapStoreKey, MapStoreTableKey}
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers._
-import org.hamcrest.{Description, TypeSafeMatcher}
 import org.testng.annotations._
 
 import scala.collection.JavaConverters._
@@ -251,33 +250,5 @@ class CassandraMapStorePluginIT {
 
   private def result(i: Int): Map[String, AnyRef] = {
     Map("myhashfield" -> "myHashValue", "myrangefield" -> s"myRangeValue$i", "key" -> "value")
-  }
-}
-
-private object CassandraSpanMatcher {
-
-  def cassandraSpan(dbInstance: String, dbStatementOp: String): CassandraSpanMatcher =
-    CassandraSpanMatcher(dbInstance, dbStatementOp)
-}
-
-private case class CassandraSpanMatcher(
-  dbInstance: String,
-  dbStatementOp: String
-) extends TypeSafeMatcher[MockSpan] {
-
-  override def matchesSafely(mockSpan: MockSpan): Boolean = {
-    hasEntry[String, AnyRef]("component", "java-cassandra").matches(mockSpan.tags()) &&
-      hasEntry[String, AnyRef]("db.instance", dbInstance).matches(mockSpan.tags()) &&
-      hasEntry[String, String](is("db.statement"), startsWith(dbStatementOp)).matches(mockSpan.tags()) &&
-      hasEntry[String, AnyRef]("db.type", "cassandra").matches(mockSpan.tags()) &&
-      hasEntry[String, AnyRef]("span.kind", "client").matches(mockSpan.tags()) &&
-      hasKey[String]("peer.hostname").matches(mockSpan.tags()) &&
-      hasKey[String]("peer.port").matches(mockSpan.tags()) &&
-      "execute".equals(mockSpan.operationName())
-  }
-
-  override def describeTo(description: Description): Unit = {
-    description.appendText("a Cassandra span tagged with db instance ")
-    description.appendText(dbInstance)
   }
 }

--- a/mapstore-cassandra-test/src/test/scala/net/spals/appbuilder/mapstore/cassandra/CassandraSpanMatcher.scala
+++ b/mapstore-cassandra-test/src/test/scala/net/spals/appbuilder/mapstore/cassandra/CassandraSpanMatcher.scala
@@ -1,0 +1,39 @@
+package net.spals.appbuilder.mapstore.cassandra
+
+import io.opentracing.mock.MockSpan
+import org.hamcrest.Matchers.{hasEntry, hasKey, is, startsWith}
+import org.hamcrest.{Description, TypeSafeMatcher}
+
+/**
+  * A Hamcrest [[org.hamcrest.Matcher]] used
+  * to match tracing spans specific to Cassandra.
+  *
+  * @author tkral
+  */
+private[cassandra] object CassandraSpanMatcher {
+
+  def cassandraSpan(dbInstance: String, dbStatementOp: String): CassandraSpanMatcher =
+    CassandraSpanMatcher(dbInstance, dbStatementOp)
+}
+
+private[cassandra] case class CassandraSpanMatcher(
+  dbInstance: String,
+  dbStatementOp: String
+) extends TypeSafeMatcher[MockSpan] {
+
+  override def matchesSafely(mockSpan: MockSpan): Boolean = {
+    hasEntry[String, AnyRef]("component", "java-cassandra").matches(mockSpan.tags()) &&
+      hasEntry[String, AnyRef]("db.instance", dbInstance).matches(mockSpan.tags()) &&
+      hasEntry[String, String](is("db.statement"), startsWith(dbStatementOp)).matches(mockSpan.tags()) &&
+      hasEntry[String, AnyRef]("db.type", "cassandra").matches(mockSpan.tags()) &&
+      hasEntry[String, AnyRef]("span.kind", "client").matches(mockSpan.tags()) &&
+      hasKey[String]("peer.hostname").matches(mockSpan.tags()) &&
+      hasKey[String]("peer.port").matches(mockSpan.tags()) &&
+      "execute".equals(mockSpan.operationName())
+  }
+
+  override def describeTo(description: Description): Unit = {
+    description.appendText("a Cassandra span tagged with db instance ")
+    description.appendText(dbInstance)
+  }
+}

--- a/mapstore-cassandra/src/main/scala/net/spals/appbuilder/mapstore/cassandra/CassandraMapStorePlugin.scala
+++ b/mapstore-cassandra/src/main/scala/net/spals/appbuilder/mapstore/cassandra/CassandraMapStorePlugin.scala
@@ -34,7 +34,7 @@ import scala.compat.java8.OptionConverters._
 private[cassandra] class CassandraMapStorePlugin @Inject() (
   @ApplicationName applicationName: String,
   cluster: Cluster
-) extends MapStorePlugin with Closeable {
+) extends MapStorePlugin {
 
   @annotations.Configuration("mapStore.cassandra.keyspace")
   @volatile

--- a/mapstore-cassandra/src/main/scala/net/spals/appbuilder/mapstore/cassandra/CassandraMapStorePlugin.scala
+++ b/mapstore-cassandra/src/main/scala/net/spals/appbuilder/mapstore/cassandra/CassandraMapStorePlugin.scala
@@ -67,7 +67,10 @@ private[cassandra] class CassandraMapStorePlugin @Inject() (
     cluster.close()
   }
 
-  override def createTable(tableName: String, tableKey: MapStoreTableKey): Boolean = {
+  override def createTable(
+    tableName: String,
+    tableKey: MapStoreTableKey
+  ): Boolean = {
     val schemaBuilder = SchemaBuilder.createTable(tableName).ifNotExists()
       .addPartitionKey(tableKey.getHashField, loadDataType(tableKey.getHashFieldType))
     tableKey.getRangeField.asScala
@@ -87,8 +90,10 @@ private[cassandra] class CassandraMapStorePlugin @Inject() (
     session.execute(schemaBuilder.toString).wasApplied()
   }
 
-  override def deleteItem(tableName: String,
-                          key: MapStoreKey): Unit = {
+  override def deleteItem(
+    tableName: String,
+    key: MapStoreKey
+  ): Unit = {
     val keyClause = CassandraKeyClause(key)
     val queryBuilder = QueryBuilder.delete().from(tableName).where(keyClause.hashClause)
     keyClause.rangeClauses.foreach(queryBuilder.and(_))
@@ -102,8 +107,10 @@ private[cassandra] class CassandraMapStorePlugin @Inject() (
     results.map(rowMapper()).toList.asJava
   }
 
-  override def getItem(tableName: String,
-                       key: MapStoreKey): Optional[java.util.Map[String, AnyRef]] = {
+  override def getItem(
+    tableName: String,
+    key: MapStoreKey
+  ): Optional[java.util.Map[String, AnyRef]] = {
     val keyClause = CassandraKeyClause(key)
     val queryBuilder = QueryBuilder.select().all().from(tableName).where(keyClause.hashClause)
     keyClause.rangeClauses.foreach(queryBuilder.and(_))
@@ -112,9 +119,11 @@ private[cassandra] class CassandraMapStorePlugin @Inject() (
     Option(result).map(rowMapper()).asJava
   }
 
-  override def getItems(tableName: String,
-                        key: MapStoreKey,
-                        options: MapQueryOptions): java.util.List[java.util.Map[String, AnyRef]] = {
+  override def getItems(
+    tableName: String,
+    key: MapStoreKey,
+    options: MapQueryOptions
+  ): java.util.List[java.util.Map[String, AnyRef]] = {
     val keyClause = CassandraKeyClause(key)
     val queryBuilder = QueryBuilder.select().all().from(tableName).where(keyClause.hashClause)
     keyClause.rangeClauses.foreach(queryBuilder.and(_))
@@ -129,9 +138,11 @@ private[cassandra] class CassandraMapStorePlugin @Inject() (
     results.map(rowMapper()).toList.asJava
   }
 
-  override def putItem(tableName: String,
-                       key: MapStoreKey,
-                       payload: java.util.Map[String, AnyRef]): java.util.Map[String, AnyRef] = {
+  override def putItem(
+    tableName: String,
+    key: MapStoreKey,
+    payload: java.util.Map[String, AnyRef]
+  ): java.util.Map[String, AnyRef] = {
     stripKey(key, payload)
 
     val keyFields = key.getRangeField.asScala.map(rangeField => List(key.getHashField, rangeField))
@@ -146,9 +157,11 @@ private[cassandra] class CassandraMapStorePlugin @Inject() (
     getItem(tableName, key).get()
   }
 
-  override def updateItem(tableName: String,
-                          key: MapStoreKey,
-                          payload: java.util.Map[String, AnyRef]): java.util.Map[String, AnyRef] = {
+  override def updateItem(
+    tableName: String,
+    key: MapStoreKey,
+    payload: java.util.Map[String, AnyRef]
+  ): java.util.Map[String, AnyRef] = {
     val keyClause = CassandraKeyClause(key)
     val queryBuilder = QueryBuilder.update(tableName).where(keyClause.hashClause)
     keyClause.rangeClauses.foreach(queryBuilder.and(_))

--- a/mapstore-core-test/src/test/java/net/spals/appbuilder/mapstore/core/mapdb/MapDBIndexMetadataTest.java
+++ b/mapstore-core-test/src/test/java/net/spals/appbuilder/mapstore/core/mapdb/MapDBIndexMetadataTest.java
@@ -1,0 +1,101 @@
+package net.spals.appbuilder.mapstore.core.mapdb;
+
+import net.spals.appbuilder.mapstore.core.model.MapStoreIndexName;
+import net.spals.appbuilder.mapstore.core.model.MapStoreTableKey;
+import org.mapdb.DB;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import java.util.Set;
+
+import static com.googlecode.catchexception.CatchException.catchException;
+import static com.googlecode.catchexception.CatchException.caughtException;
+import static net.spals.appbuilder.mapstore.core.mapdb.MapDBIndexMetadata.*;
+import static net.spals.appbuilder.mapstore.core.model.MapStoreIndexName.indexName;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+
+/**
+ * Unit tests for {@link MapDBIndexMetadata}.
+ *
+ * @author tkral
+ */
+public class MapDBIndexMetadataTest {
+
+    @DataProvider
+    Object[][] indexMetadataProvider() {
+        final MapStoreIndexName indexName = indexName("table", "index");
+        return new Object[][] {
+            // Case: Hash field only
+            {indexMetadata(indexName,
+                new MapStoreTableKey.Builder().setHash("hashField", String.class).build()),
+                "table.index?hashField=java.lang.String"},
+            // Case: Hash and range fields
+            {indexMetadata(indexName,
+                new MapStoreTableKey.Builder().setHash("hashField", String.class).setRange("rangeField", Integer.class).build()),
+                "table.index?hashField=java.lang.String&rangeField=java.lang.Integer"},
+        };
+    }
+
+    @Test(dataProvider = "indexMetadataProvider")
+    public void testToString(
+        final MapDBIndexMetadata indexMetadata,
+        final String expectedString
+    ) {
+        assertThat(indexMetadata.toString(), is(expectedString));
+    }
+
+    @Test(dataProvider = "indexMetadataProvider")
+    public void testFromString(
+        final MapDBIndexMetadata expectedIndexMetadata,
+        final String metadataStr
+    ) {
+        assertThat(fromString(metadataStr), is(expectedIndexMetadata));
+    }
+
+    @Test
+    public void testFindIndexMetadataFromIndexNameMissing() {
+        final DB mapDB = new MapDBProvider().get();
+
+        catchException(() -> findIndexMetadata(mapDB, MapStoreIndexName.fromString("table.index")));
+        assertThat(caughtException(), instanceOf(IllegalArgumentException.class));
+    }
+
+    @Test(dataProvider = "indexMetadataProvider")
+    public void testFindIndexMetadataFromIndexName(
+        final MapDBIndexMetadata expectedIndexMetadata,
+        final String metadataStr
+    ) {
+        final DB mapDB = new MapDBProvider().get();
+        mapDB.treeMap(metadataStr).createOrOpen();
+
+        final MapDBIndexMetadata indexMetadata = findIndexMetadata(mapDB, MapStoreIndexName.fromString("table.index"));
+        assertThat(indexMetadata, is(expectedIndexMetadata));
+    }
+
+    @Test
+    public void testFindIndexMetadataFromTableNameMissing() {
+        final DB mapDB = new MapDBProvider().get();
+
+        final Set<MapDBIndexMetadata> indexMetadatas = findIndexMetadata(mapDB, "table");
+        assertThat(indexMetadatas, emptyCollectionOf(MapDBIndexMetadata.class));
+    }
+
+    @Test
+    public void testFindIndexMetadataFromTableName() {
+        final DB mapDB = new MapDBProvider().get();
+
+        final MapStoreIndexName indexName1 = indexName("table", "index1");
+        final MapDBIndexMetadata indexMetadata1 = indexMetadata(indexName1,
+            new MapStoreTableKey.Builder().setHash("hashField", String.class).build());
+        mapDB.treeMap(indexMetadata1.toString()).createOrOpen();
+
+        final MapStoreIndexName indexName2 = indexName("table", "index2");
+        final MapDBIndexMetadata indexMetadata2 = indexMetadata(indexName2,
+            new MapStoreTableKey.Builder().setHash("hashField", String.class).build());
+        mapDB.treeMap(indexMetadata2.toString()).createOrOpen();
+
+        final Set<MapDBIndexMetadata> indexMetadatas = findIndexMetadata(mapDB, "table");
+        assertThat(indexMetadatas, hasSize(2));
+    }
+}

--- a/mapstore-core-test/src/test/java/net/spals/appbuilder/mapstore/core/mapdb/MapDBMapStoreIndexPluginTest.java
+++ b/mapstore-core-test/src/test/java/net/spals/appbuilder/mapstore/core/mapdb/MapDBMapStoreIndexPluginTest.java
@@ -1,0 +1,167 @@
+package net.spals.appbuilder.mapstore.core.mapdb;
+
+import com.google.common.collect.ImmutableMap;
+import net.spals.appbuilder.mapstore.core.MapStoreIndexPlugin;
+import net.spals.appbuilder.mapstore.core.MapStorePlugin;
+import net.spals.appbuilder.mapstore.core.model.MapStoreIndexName;
+import net.spals.appbuilder.mapstore.core.model.MapStoreKey;
+import net.spals.appbuilder.mapstore.core.model.MapStoreTableKey;
+import org.mapdb.DB;
+import org.mapdb.DBMaker;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+import static net.spals.appbuilder.mapstore.core.mapdb.MapDBIndexMetadata.findIndexMetadata;
+import static net.spals.appbuilder.mapstore.core.mapdb.MapDBIndexMetadata.indexMetadata;
+import static net.spals.appbuilder.mapstore.core.model.MapQueryOptions.defaultOptions;
+import static net.spals.appbuilder.mapstore.core.model.MapStoreIndexName.indexName;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+
+/**
+ * Unit tests for {@link MapDBMapStoreIndexPlugin}.
+ *
+ * @author tkral
+ */
+public class MapDBMapStoreIndexPluginTest {
+
+    private static final MapStoreIndexName INDEX_NAME = indexName("myTable", "myIndex");
+
+    private static final MapStoreTableKey HASH_ONLY_INDEX_KEY =
+        new MapStoreTableKey.Builder().setHash("indexHashField", String.class).build();
+    private static final MapStoreTableKey HASH_ONLY_TABLE_KEY =
+        new MapStoreTableKey.Builder().setHash("tableHashField", String.class).build();
+
+    private static final MapStoreTableKey HASH_RANGE_INDEX_KEY =
+        new MapStoreTableKey.Builder().setHash("indexHashField", String.class)
+            .setRange("indexRangeField", Integer.class).build();
+    private static final MapStoreTableKey HASH_RANGE_TABLE_KEY =
+        new MapStoreTableKey.Builder().setHash("tableHashField", String.class)
+            .setRange("tableRangeField", Integer.class).build();
+
+    @DataProvider
+    Object[][] tableKeyProvider() {
+        return new Object[][] {
+            {HASH_ONLY_TABLE_KEY, HASH_ONLY_INDEX_KEY},
+            {HASH_RANGE_TABLE_KEY, HASH_RANGE_INDEX_KEY},
+            {HASH_RANGE_TABLE_KEY, HASH_ONLY_INDEX_KEY},
+        };
+    }
+
+    @Test(dataProvider = "tableKeyProvider")
+    public void testCreateIndex(final MapStoreTableKey tableKey, final MapStoreTableKey indexKey) {
+        final DB mapDB = DBMaker.memoryDB().make();
+        final MapStorePlugin storePlugin = new MapDBMapStorePlugin(mapDB);
+        final MapStoreIndexPlugin storeIndexPlugin = new MapDBMapStoreIndexPlugin(mapDB, storePlugin);
+
+        storePlugin.createTable(INDEX_NAME.getTableName(), tableKey);
+        storeIndexPlugin.createIndex(INDEX_NAME, indexKey);
+
+        final Set<MapDBIndexMetadata> myTableIndexes = findIndexMetadata(mapDB, "myTable");
+        assertThat(myTableIndexes, contains(indexMetadata(INDEX_NAME, indexKey)));
+    }
+
+    @Test
+    public void testEmptyGetItem() {
+        final DB mapDB = DBMaker.memoryDB().make();
+        final MapStorePlugin storePlugin = new MapDBMapStorePlugin(mapDB);
+        final MapStoreIndexPlugin storeIndexPlugin = new MapDBMapStoreIndexPlugin(mapDB, storePlugin);
+
+        storePlugin.createTable(INDEX_NAME.getTableName(), HASH_ONLY_TABLE_KEY);
+        storeIndexPlugin.createIndex(INDEX_NAME, HASH_ONLY_INDEX_KEY);
+
+        final MapStoreKey indexItemKey = new MapStoreKey.Builder().setHash("indexHashField", "index").build();
+        assertThat(storeIndexPlugin.getItem(INDEX_NAME, indexItemKey), is(Optional.empty()));
+    }
+
+    @Test
+    public void testEmptyGetItems() {
+        final DB mapDB = DBMaker.memoryDB().make();
+        final MapStorePlugin storePlugin = new MapDBMapStorePlugin(mapDB);
+        final MapStoreIndexPlugin storeIndexPlugin = new MapDBMapStoreIndexPlugin(mapDB, storePlugin);
+
+        storePlugin.createTable(INDEX_NAME.getTableName(), HASH_ONLY_TABLE_KEY);
+        storeIndexPlugin.createIndex(INDEX_NAME, HASH_ONLY_INDEX_KEY);
+
+        final MapStoreKey indexItemKey = new MapStoreKey.Builder().setHash("indexHashField", "index").build();
+        assertThat(storeIndexPlugin.getItems(INDEX_NAME, indexItemKey, defaultOptions()), empty());
+    }
+
+    @Test
+    public void testFillIndexAfterCreate() {
+        final DB mapDB = DBMaker.memoryDB().make();
+        final MapStorePlugin storePlugin = new MapDBMapStorePlugin(mapDB);
+        final MapStoreIndexPlugin storeIndexPlugin = new MapDBMapStoreIndexPlugin(mapDB, storePlugin);
+
+        storePlugin.createTable(INDEX_NAME.getTableName(), HASH_ONLY_TABLE_KEY);
+
+        final MapStoreKey tableItemKey = new MapStoreKey.Builder().setHash("tableHashField", "table").build();
+        storePlugin.putItem(INDEX_NAME.getTableName(), tableItemKey, ImmutableMap.of("indexHashField", "index"));
+
+        storeIndexPlugin.createIndex(INDEX_NAME, HASH_ONLY_INDEX_KEY);
+
+        final MapStoreKey indexItemKey = new MapStoreKey.Builder().setHash("indexHashField", "index").build();
+        final Optional<Map<String, Object>> indexItem = storeIndexPlugin.getItem(INDEX_NAME, indexItemKey);
+        assertThat(indexItem, not(Optional.empty()));
+        assertThat(indexItem.get(), is(ImmutableMap.of("tableHashField", "table", "indexHashField", "index")));
+    }
+
+    @Test(enabled = false)
+    public void testGetItem() {
+        final DB mapDB = DBMaker.memoryDB().make();
+        final MapStorePlugin storePlugin = new MapDBMapStorePlugin(mapDB);
+        final MapStoreIndexPlugin storeIndexPlugin = new MapDBMapStoreIndexPlugin(mapDB, storePlugin);
+
+        storePlugin.createTable(INDEX_NAME.getTableName(), HASH_ONLY_TABLE_KEY);
+        storeIndexPlugin.createIndex(INDEX_NAME, HASH_ONLY_INDEX_KEY);
+
+        final MapStoreKey tableItemKey = new MapStoreKey.Builder().setHash("tableHashField", "table").build();
+        storePlugin.putItem(INDEX_NAME.getTableName(), tableItemKey, ImmutableMap.of("indexHashField", "index"));
+
+        final MapStoreKey indexItemKey = new MapStoreKey.Builder().setHash("indexHashField", "index").build();
+        final Optional<Map<String, Object>> indexItem = storeIndexPlugin.getItem(INDEX_NAME, indexItemKey);
+        assertThat(indexItem, not(Optional.empty()));
+        assertThat(indexItem.get(), is(ImmutableMap.of("tableHashField", "table", "indexHashField", "index")));
+    }
+
+    @Test(enabled = false)
+    public void testUpdateItem() {
+        final DB mapDB = DBMaker.memoryDB().make();
+        final MapStorePlugin storePlugin = new MapDBMapStorePlugin(mapDB);
+        final MapStoreIndexPlugin storeIndexPlugin = new MapDBMapStoreIndexPlugin(mapDB, storePlugin);
+
+        storePlugin.createTable(INDEX_NAME.getTableName(), HASH_ONLY_TABLE_KEY);
+        storeIndexPlugin.createIndex(INDEX_NAME, HASH_ONLY_INDEX_KEY);
+
+        final MapStoreKey tableItemKey = new MapStoreKey.Builder().setHash("tableHashField", "table").build();
+        storePlugin.putItem(INDEX_NAME.getTableName(), tableItemKey, ImmutableMap.of("indexHashField", "index"));
+        storePlugin.updateItem(INDEX_NAME.getTableName(), tableItemKey, ImmutableMap.of("key", "value"));
+
+        final MapStoreKey indexItemKey = new MapStoreKey.Builder().setHash("indexHashField", "index").build();
+        final Optional<Map<String, Object>> indexItem = storeIndexPlugin.getItem(INDEX_NAME, indexItemKey);
+        assertThat(indexItem, not(Optional.empty()));
+        assertThat(indexItem.get(), is(ImmutableMap.of("tableHashField", "table", "indexHashField", "index", "key", "value")));
+    }
+
+    @Test(enabled = false)
+    public void testDeleteItem() {
+        final DB mapDB = DBMaker.memoryDB().make();
+        final MapStorePlugin storePlugin = new MapDBMapStorePlugin(mapDB);
+        final MapStoreIndexPlugin storeIndexPlugin = new MapDBMapStoreIndexPlugin(mapDB, storePlugin);
+
+        storePlugin.createTable(INDEX_NAME.getTableName(), HASH_ONLY_TABLE_KEY);
+        storeIndexPlugin.createIndex(INDEX_NAME, HASH_ONLY_INDEX_KEY);
+
+        final MapStoreKey tableItemKey = new MapStoreKey.Builder().setHash("tableHashField", "table").build();
+        storePlugin.putItem(INDEX_NAME.getTableName(), tableItemKey, ImmutableMap.of("indexHashField", "index"));
+        storePlugin.deleteItem(INDEX_NAME.getTableName(), tableItemKey);
+
+        final MapStoreKey indexItemKey = new MapStoreKey.Builder().setHash("indexHashField", "index").build();
+        final Optional<Map<String, Object>> indexItem = storeIndexPlugin.getItem(INDEX_NAME, indexItemKey);
+        assertThat(indexItem, is(Optional.empty()));
+    }
+}

--- a/mapstore-core-test/src/test/java/net/spals/appbuilder/mapstore/core/mapdb/MapDBMapStoreIndexPluginTest.java
+++ b/mapstore-core-test/src/test/java/net/spals/appbuilder/mapstore/core/mapdb/MapDBMapStoreIndexPluginTest.java
@@ -110,7 +110,7 @@ public class MapDBMapStoreIndexPluginTest {
         assertThat(indexItem.get(), is(ImmutableMap.of("tableHashField", "table", "indexHashField", "index")));
     }
 
-    @Test(enabled = false)
+    @Test
     public void testGetItem() {
         final DB mapDB = DBMaker.memoryDB().make();
         final MapStorePlugin storePlugin = new MapDBMapStorePlugin(mapDB);
@@ -128,7 +128,7 @@ public class MapDBMapStoreIndexPluginTest {
         assertThat(indexItem.get(), is(ImmutableMap.of("tableHashField", "table", "indexHashField", "index")));
     }
 
-    @Test(enabled = false)
+    @Test
     public void testUpdateItem() {
         final DB mapDB = DBMaker.memoryDB().make();
         final MapStorePlugin storePlugin = new MapDBMapStorePlugin(mapDB);
@@ -147,7 +147,7 @@ public class MapDBMapStoreIndexPluginTest {
         assertThat(indexItem.get(), is(ImmutableMap.of("tableHashField", "table", "indexHashField", "index", "key", "value")));
     }
 
-    @Test(enabled = false)
+    @Test
     public void testDeleteItem() {
         final DB mapDB = DBMaker.memoryDB().make();
         final MapStorePlugin storePlugin = new MapDBMapStorePlugin(mapDB);

--- a/mapstore-core-test/src/test/java/net/spals/appbuilder/mapstore/core/model/MapStoreIndexNameTest.java
+++ b/mapstore-core-test/src/test/java/net/spals/appbuilder/mapstore/core/model/MapStoreIndexNameTest.java
@@ -1,0 +1,27 @@
+package net.spals.appbuilder.mapstore.core.model;
+
+import org.testng.annotations.Test;
+
+import static net.spals.appbuilder.mapstore.core.model.MapStoreIndexName.fromString;
+import static net.spals.appbuilder.mapstore.core.model.MapStoreIndexName.indexName;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+/**
+ * Unit tests for {@link MapStoreIndexName}.
+ *
+ * @author tkral
+ */
+public class MapStoreIndexNameTest {
+
+    @Test
+    public void testToString() {
+        final MapStoreIndexName indexName = indexName("table", "index");
+        assertThat(indexName.toString(), is("table.index"));
+    }
+
+    @Test
+    public void testFromString() {
+        assertThat(fromString("table.index"), is(indexName("table", "index")));
+    }
+}

--- a/mapstore-core/src/main/java/net/spals/appbuilder/mapstore/core/MapStore.java
+++ b/mapstore-core/src/main/java/net/spals/appbuilder/mapstore/core/MapStore.java
@@ -9,22 +9,11 @@ import java.util.Map;
 import java.util.Optional;
 
 /**
- * A NoSQL storage service which holds
- * data in maps.
+ * A NoSQL storage service which holds data in maps.
  *
  * @author tkral
  */
 public interface MapStore {
-
-    /**
-     * Creates a secondary index for the given table
-     * with the given key.
-     *
-     * Note that the table must already exist.
-     *
-     * @return true iff the creation was successful
-     */
-//    boolean createIndex(String tableName, String indexName, MapStoreTableKey indexKey);
 
     /**
      * Creates a table with the given key.
@@ -35,14 +24,10 @@ public interface MapStore {
      *
      * @return true iff the table exists after execution
      */
-    boolean createTable(String tableName, MapStoreTableKey tableKey);
-
-    /**
-     * Drops a secondary index for the given table.
-     *
-     * @return true iff the drop was successful
-     */
-//    boolean dropIndex(String tableName, String indexName);
+    boolean createTable(
+        String tableName,
+        MapStoreTableKey tableKey
+    );
 
     /**
      * Drops a table.
@@ -58,7 +43,10 @@ public interface MapStore {
      * This should be idempotent if the item
      * does not exist.
      */
-    void deleteItem(String tableName, MapStoreKey key);
+    void deleteItem(
+        String tableName,
+        MapStoreKey key
+    );
 
     /**
      * Retrieves all items from the given table
@@ -73,20 +61,31 @@ public interface MapStore {
      * Returns {@link Optional#empty()} if no
      * item exists with the given key.
      */
-    Optional<Map<String, Object>> getItem(String tableName, MapStoreKey key);
+    Optional<Map<String, Object>> getItem(
+        String tableName,
+        MapStoreKey key
+    );
 
     /**
      * Queries all items from the given table
      * which match the given {@link MapStoreKey}
      * range key operator.
      */
-    List<Map<String, Object>> getItems(String tableName, MapStoreKey key, MapQueryOptions options);
+    List<Map<String, Object>> getItems(
+        String tableName,
+        MapStoreKey key,
+        MapQueryOptions options
+    );
 
     /**
      * Adds an item to the given table
      * under the given key.
      */
-    Map<String, Object> putItem(String tableName, MapStoreKey key, Map<String, Object> payload);
+    Map<String, Object> putItem(
+        String tableName,
+        MapStoreKey key,
+        Map<String, Object> payload
+    );
 
     /**
      * Updates an item in the given table
@@ -96,5 +95,9 @@ public interface MapStore {
      * this will fallback to {@link #putItem(String, MapStoreKey, Map)}
      * semantics.
      */
-    Map<String, Object> updateItem(String tableName, MapStoreKey key, Map<String, Object> payload);
+    Map<String, Object> updateItem(
+        String tableName,
+        MapStoreKey key,
+        Map<String, Object> payload
+    );
 }

--- a/mapstore-core/src/main/java/net/spals/appbuilder/mapstore/core/MapStore.java
+++ b/mapstore-core/src/main/java/net/spals/appbuilder/mapstore/core/MapStore.java
@@ -4,6 +4,7 @@ import net.spals.appbuilder.mapstore.core.model.MapQueryOptions;
 import net.spals.appbuilder.mapstore.core.model.MapStoreKey;
 import net.spals.appbuilder.mapstore.core.model.MapStoreTableKey;
 
+import java.io.Closeable;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -13,7 +14,7 @@ import java.util.Optional;
  *
  * @author tkral
  */
-public interface MapStore {
+public interface MapStore extends Closeable {
 
     /**
      * Creates a table with the given key.

--- a/mapstore-core/src/main/java/net/spals/appbuilder/mapstore/core/MapStoreIndex.java
+++ b/mapstore-core/src/main/java/net/spals/appbuilder/mapstore/core/MapStoreIndex.java
@@ -1,0 +1,65 @@
+package net.spals.appbuilder.mapstore.core;
+
+import net.spals.appbuilder.mapstore.core.model.MapQueryOptions;
+import net.spals.appbuilder.mapstore.core.model.MapStoreIndexName;
+import net.spals.appbuilder.mapstore.core.model.MapStoreKey;
+import net.spals.appbuilder.mapstore.core.model.MapStoreTableKey;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * A service which represents an index of a {@link MapStore}.
+ * <p>
+ * Note that this is a separate service because not all
+ * {@link MapStorePlugin} implementations may support indexes.
+ * Also note, that indexes are read only. They will always
+ * be populated automatically with writes to {@link MapStore}.
+ *
+ * @author tkral
+ */
+public interface MapStoreIndex {
+
+    /**
+     * Creates an index with the given key.
+     *
+     * Note that the table must already exist.
+     *
+     * @return true iff the creation was successful
+     */
+    boolean createIndex(
+        MapStoreIndexName indexName,
+        MapStoreTableKey indexKey
+    );
+
+    /**
+     * Drops an index.
+     *
+     * @return true iff the drop was successful
+     */
+    boolean dropIndex(MapStoreIndexName indexName);
+
+    /**
+     * Retrieves an item from the given index
+     * with the given key.
+     *
+     * Returns {@link Optional#empty()} if no
+     * item exists with the given key.
+     */
+    Optional<Map<String, Object>> getItem(
+        MapStoreIndexName indexName,
+        MapStoreKey key
+    );
+
+    /**
+     * Queries all items from the given index
+     * which match the given {@link MapStoreKey}
+     * range key operator.
+     */
+    List<Map<String, Object>> getItems(
+        MapStoreIndexName indexName,
+        MapStoreKey key,
+        MapQueryOptions options
+    );
+}

--- a/mapstore-core/src/main/java/net/spals/appbuilder/mapstore/core/MapStoreIndex.java
+++ b/mapstore-core/src/main/java/net/spals/appbuilder/mapstore/core/MapStoreIndex.java
@@ -5,6 +5,7 @@ import net.spals.appbuilder.mapstore.core.model.MapStoreIndexName;
 import net.spals.appbuilder.mapstore.core.model.MapStoreKey;
 import net.spals.appbuilder.mapstore.core.model.MapStoreTableKey;
 
+import java.io.Closeable;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -19,7 +20,7 @@ import java.util.Optional;
  *
  * @author tkral
  */
-public interface MapStoreIndex {
+public interface MapStoreIndex extends Closeable {
 
     /**
      * Creates an index with the given key.

--- a/mapstore-core/src/main/java/net/spals/appbuilder/mapstore/core/MapStoreIndexPlugin.java
+++ b/mapstore-core/src/main/java/net/spals/appbuilder/mapstore/core/MapStoreIndexPlugin.java
@@ -1,0 +1,6 @@
+package net.spals.appbuilder.mapstore.core;
+
+/**
+ * @author tkral
+ */
+public interface MapStoreIndexPlugin extends MapStoreIndex {  }

--- a/mapstore-core/src/main/java/net/spals/appbuilder/mapstore/core/MapStoreIndexProvider.java
+++ b/mapstore-core/src/main/java/net/spals/appbuilder/mapstore/core/MapStoreIndexProvider.java
@@ -1,0 +1,93 @@
+package net.spals.appbuilder.mapstore.core;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.inject.Inject;
+import com.google.inject.Provider;
+import com.netflix.governator.annotations.Configuration;
+import com.typesafe.config.ConfigException;
+import net.spals.appbuilder.annotations.service.AutoBindProvider;
+import net.spals.appbuilder.mapstore.core.model.MapQueryOptions;
+import net.spals.appbuilder.mapstore.core.model.MapStoreIndexName;
+import net.spals.appbuilder.mapstore.core.model.MapStoreKey;
+import net.spals.appbuilder.mapstore.core.model.MapStoreTableKey;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static net.spals.appbuilder.mapstore.core.MapStoreProvider.DelegatingMapStore.checkSingleItemKey;
+
+/**
+ * @author tkral
+ */
+@AutoBindProvider
+class MapStoreIndexProvider implements Provider<MapStoreIndex> {
+
+    @Configuration("mapStore.system")
+    private volatile String storeSystem;
+
+    private final Map<String, MapStoreIndexPlugin> storeIndexPluginMap;
+
+    @Inject
+    MapStoreIndexProvider(final Map<String, MapStoreIndexPlugin> storeIndexPluginMap) {
+        this.storeIndexPluginMap = storeIndexPluginMap;
+    }
+
+    @Override
+    public MapStoreIndex get() {
+        final MapStoreIndexPlugin storeIndexPlugin = Optional.ofNullable(storeIndexPluginMap.get(storeSystem))
+            .orElseThrow(() -> new ConfigException.BadValue("mapStore.system",
+                    "No Map Store Index plugin found for : " + storeSystem));
+
+        return new DelegatingMapStoreIndex(storeIndexPlugin);
+    }
+
+    @VisibleForTesting
+    static class DelegatingMapStoreIndex implements MapStoreIndex {
+
+        private final MapStoreIndexPlugin pluginDelegate;
+
+        DelegatingMapStoreIndex(final MapStoreIndexPlugin pluginDelegate) {
+            this.pluginDelegate = pluginDelegate;
+        }
+
+        @Override
+        public void close() {
+            // Plugins should register their close() method
+            // in the pre-destroy lifecycle so we're sure that
+            // everything is properly torn down. Therefore, there's
+            // nothing to do here.
+        }
+
+        @Override
+        public boolean createIndex(
+            final MapStoreIndexName indexName,
+            final MapStoreTableKey indexKey
+        ) {
+            return pluginDelegate.createIndex(indexName, indexKey);
+        }
+
+        @Override
+        public boolean dropIndex(final MapStoreIndexName indexName) {
+            return pluginDelegate.dropIndex(indexName);
+        }
+
+        @Override
+        public Optional<Map<String, Object>> getItem(
+            final MapStoreIndexName indexName,
+            final MapStoreKey key
+        ) {
+            checkSingleItemKey(key);
+            return pluginDelegate.getItem(indexName, key);
+        }
+
+        @Override
+        public List<Map<String, Object>> getItems(
+            final MapStoreIndexName indexName,
+            final MapStoreKey key,
+            final MapQueryOptions options
+        ) {
+            return pluginDelegate.getItems(indexName, key, options);
+        }
+    }
+}

--- a/mapstore-core/src/main/java/net/spals/appbuilder/mapstore/core/MapStoreIndexProvider.java
+++ b/mapstore-core/src/main/java/net/spals/appbuilder/mapstore/core/MapStoreIndexProvider.java
@@ -15,12 +15,13 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
+import static net.spals.appbuilder.annotations.service.AutoBindProvider.ProviderScope.LAZY_SINGLETON;
 import static net.spals.appbuilder.mapstore.core.MapStoreProvider.DelegatingMapStore.checkSingleItemKey;
 
 /**
  * @author tkral
  */
-@AutoBindProvider
+@AutoBindProvider(LAZY_SINGLETON)
 class MapStoreIndexProvider implements Provider<MapStoreIndex> {
 
     @Configuration("mapStore.system")

--- a/mapstore-core/src/main/java/net/spals/appbuilder/mapstore/core/MapStoreProvider.java
+++ b/mapstore-core/src/main/java/net/spals/appbuilder/mapstore/core/MapStoreProvider.java
@@ -59,6 +59,14 @@ class MapStoreProvider implements Provider<MapStore> {
         }
 
         @Override
+        public void close() {
+            // Plugins should register their close() method
+            // in the pre-destroy lifecycle so we're sure that
+            // everything is properly torn down. Therefore, there's
+            // nothing to do here.
+        }
+
+        @Override
         public boolean createTable(
             final String tableName,
             final MapStoreTableKey tableKey

--- a/mapstore-core/src/main/java/net/spals/appbuilder/mapstore/core/MapStoreProvider.java
+++ b/mapstore-core/src/main/java/net/spals/appbuilder/mapstore/core/MapStoreProvider.java
@@ -158,7 +158,7 @@ class MapStoreProvider implements Provider<MapStore> {
         }
 
         @VisibleForTesting
-        void checkKeyField(
+        static void checkKeyField(
             final String keyField,
             final Object keyValue,
             final Map<String, Object> payload
@@ -169,7 +169,7 @@ class MapStoreProvider implements Provider<MapStore> {
         }
 
         @VisibleForTesting
-        void checkPutItem(final Map<String, Object> payload) {
+        static void checkPutItem(final Map<String, Object> payload) {
             // Null or empty values have special semantics in updateItem so we'll disallow them here.
             final Set<String> nullValueKeys = payload.entrySet().stream()
                     .filter(isNullOrEmptyEntry())
@@ -179,7 +179,7 @@ class MapStoreProvider implements Provider<MapStore> {
         }
 
         @VisibleForTesting
-        void checkSingleItemKey(final MapStoreKey key) {
+        static void checkSingleItemKey(final MapStoreKey key) {
             if (key.getRangeField().isPresent()) {
                 checkArgument(key.getRangeKey().getOperator() == Standard.EQUAL_TO,
                         "Illegal range operator found (%s). You must use EQUAL_TO with value", key.getRangeKey().getOperator());
@@ -190,7 +190,7 @@ class MapStoreProvider implements Provider<MapStore> {
         }
 
         @VisibleForTesting
-        void checkWriteItem(
+        static void checkWriteItem(
             final MapStoreKey key,
             final Map<String, Object> payload
         ) {

--- a/mapstore-core/src/main/java/net/spals/appbuilder/mapstore/core/MapStoreProvider.java
+++ b/mapstore-core/src/main/java/net/spals/appbuilder/mapstore/core/MapStoreProvider.java
@@ -59,8 +59,10 @@ class MapStoreProvider implements Provider<MapStore> {
         }
 
         @Override
-        public boolean createTable(final String tableName,
-                                   final MapStoreTableKey tableKey) {
+        public boolean createTable(
+            final String tableName,
+            final MapStoreTableKey tableKey
+        ) {
             return pluginDelegate.createTable(tableName, tableKey);
         }
 
@@ -70,8 +72,10 @@ class MapStoreProvider implements Provider<MapStore> {
         }
 
         @Override
-        public void deleteItem(final String tableName,
-                               final MapStoreKey key) {
+        public void deleteItem(
+            final String tableName,
+            final MapStoreKey key
+        ) {
             checkSingleItemKey(key);
             pluginDelegate.deleteItem(tableName, key);
         }
@@ -82,8 +86,10 @@ class MapStoreProvider implements Provider<MapStore> {
         }
 
         @Override
-        public Optional<Map<String, Object>> getItem(final String tableName,
-                                                     final MapStoreKey key) {
+        public Optional<Map<String, Object>> getItem(
+            final String tableName,
+            final MapStoreKey key
+        ) {
             final Optional<SyntacticSugar> sugarOp = SyntacticSugar.fromName(key.getRangeKey().getOperator().toString());
             if (sugarOp.isPresent()) {
                 switch (sugarOp.get()) {
@@ -99,9 +105,11 @@ class MapStoreProvider implements Provider<MapStore> {
         }
 
         @Override
-        public List<Map<String, Object>> getItems(final String tableName,
-                                                  final MapStoreKey key,
-                                                  final MapQueryOptions options) {
+        public List<Map<String, Object>> getItems(
+            final String tableName,
+            final MapStoreKey key,
+            final MapQueryOptions options
+        ) {
             final Optional<SyntacticSugar> sugarOp = SyntacticSugar.fromName(key.getRangeKey().getOperator().toString());
             if (sugarOp.isPresent()) {
                 switch (sugarOp.get()) {
@@ -114,18 +122,22 @@ class MapStoreProvider implements Provider<MapStore> {
         }
 
         @Override
-        public Map<String, Object> putItem(final String tableName,
-                                           final MapStoreKey key,
-                                           final Map<String, Object> payload) {
+        public Map<String, Object> putItem(
+            final String tableName,
+            final MapStoreKey key,
+            final Map<String, Object> payload
+        ) {
             checkWriteItem(key, payload);
             checkPutItem(payload);
             return pluginDelegate.putItem(tableName, key, payload);
         }
 
         @Override
-        public Map<String, Object> updateItem(final String tableName,
-                                              final MapStoreKey key,
-                                              final Map<String, Object> payload) {
+        public Map<String, Object> updateItem(
+            final String tableName,
+            final MapStoreKey key,
+            final Map<String, Object> payload
+        ) {
             checkWriteItem(key, payload);
 
             final Optional<Map<String, Object>> item = getItem(tableName, key);
@@ -138,7 +150,11 @@ class MapStoreProvider implements Provider<MapStore> {
         }
 
         @VisibleForTesting
-        void checkKeyField(final String keyField, final Object keyValue, final Map<String, Object> payload) {
+        void checkKeyField(
+            final String keyField,
+            final Object keyValue,
+            final Map<String, Object> payload
+        ) {
             checkArgument(!payload.containsKey(keyField) || keyValue.equals(payload.get(keyField)),
                     "Mismatched key value (%s) and payload field value (%s)",
                     keyValue, payload.get(keyField));
@@ -166,7 +182,10 @@ class MapStoreProvider implements Provider<MapStore> {
         }
 
         @VisibleForTesting
-        void checkWriteItem(final MapStoreKey key, final Map<String, Object> payload) {
+        void checkWriteItem(
+            final MapStoreKey key,
+            final Map<String, Object> payload
+        ) {
             checkArgument(!payload.isEmpty(), "Cannot write item with empty payload");
             // Ensure that the hash value matches what's in the payload (or is absent)
             checkKeyField(key.getHashField(), key.getHashValue(), payload);
@@ -177,7 +196,10 @@ class MapStoreProvider implements Provider<MapStore> {
         }
 
         // Run max syntactic sugar operation
-        Optional<Map<String, Object>> getMaxItem(final String tableName, final MapStoreKey key) {
+        Optional<Map<String, Object>> getMaxItem(
+            final String tableName,
+            final MapStoreKey key
+        ) {
             checkArgument(key.getRangeKey().getOperator() == SyntacticSugar.MAX);
 
             // The max operator is equivalent to grabbing all range keys, sorting
@@ -192,7 +214,10 @@ class MapStoreProvider implements Provider<MapStore> {
         }
 
         // Run min syntactic sugar operation
-        Optional<Map<String, Object>> getMinItem(final String tableName, final MapStoreKey key) {
+        Optional<Map<String, Object>> getMinItem(
+            final String tableName,
+            final MapStoreKey key
+        ) {
             checkArgument(key.getRangeKey().getOperator() == SyntacticSugar.MIN);
 
             // The min operator is equivalent to grabbing all range keys, sorting

--- a/mapstore-core/src/main/java/net/spals/appbuilder/mapstore/core/mapdb/MapDBIndexMetadata.java
+++ b/mapstore-core/src/main/java/net/spals/appbuilder/mapstore/core/mapdb/MapDBIndexMetadata.java
@@ -1,0 +1,96 @@
+package net.spals.appbuilder.mapstore.core.mapdb;
+
+import com.google.auto.value.AutoValue;
+import net.spals.appbuilder.mapstore.core.model.MapStoreIndexName;
+import net.spals.appbuilder.mapstore.core.model.MapStoreTableKey;
+import org.mapdb.DB;
+
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkNotNull;
+
+/**
+ * @author tkral
+ */
+@AutoValue
+abstract class MapDBIndexMetadata {
+
+    static MapDBIndexMetadata indexMetadata(
+        final MapStoreIndexName indexName,
+        final MapStoreTableKey indexKey
+    ) {
+        return new AutoValue_MapDBIndexMetadata(indexName, indexKey);
+    }
+
+    static MapDBIndexMetadata findIndexMetadata(
+        final DB mapDB,
+        final MapStoreIndexName indexName
+    ) {
+        final Optional<String> indexMetadataStrOpt = StreamSupport.stream(mapDB.getAllNames().spliterator(), false)
+            .filter(name -> name.startsWith(indexName.toString() + "?"))
+            .findAny();
+
+        checkArgument(indexMetadataStrOpt.isPresent(),
+            "No index with name %s exists.", indexName.toString());
+        return fromString(indexMetadataStrOpt.get());
+    }
+
+    static Set<MapDBIndexMetadata> findIndexMetadata(
+        final DB mapDB,
+        final String tableName
+    ) {
+        return StreamSupport.stream(mapDB.getAllNames().spliterator(), false)
+            .filter(name -> name.startsWith(tableName + "."))
+            .map(name -> fromString(name))
+            .collect(Collectors.toSet());
+    }
+
+    static MapDBIndexMetadata fromString(final String indexMetadataStr) {
+        final String[] parsedIndexMetadataStr = checkNotNull(indexMetadataStr).split("\\?", 2);
+
+        final MapStoreIndexName indexName = MapStoreIndexName.fromString(parsedIndexMetadataStr[0]);
+        final String[] parsedKeys = parsedIndexMetadataStr[1].split("&", 2);
+
+        final MapStoreTableKey.Builder indexKeyBuilder = new MapStoreTableKey.Builder();
+
+        final String[] parsedHashKey = parsedKeys[0].split("=", 2);
+        indexKeyBuilder.setHashField(parsedHashKey[0]);
+        indexKeyBuilder.setHashFieldType(loadKeyClass(parsedHashKey[1]));
+
+        Optional.of(parsedKeys).filter(keys -> keys.length > 1)
+            .ifPresent(keys -> {
+                final String[] parsedRangeKey = keys[1].split("=", 2);
+                indexKeyBuilder.setRangeField(parsedRangeKey[0]);
+                indexKeyBuilder.setRangeFieldType((Class<? extends Comparable>)loadKeyClass(parsedRangeKey[1]));
+            });
+
+        return new AutoValue_MapDBIndexMetadata(indexName, indexKeyBuilder.build());
+    }
+
+    private static Class<?> loadKeyClass(final String className) {
+        try {
+            return Class.forName(className);
+        } catch (ClassNotFoundException e) {
+            throw new IllegalStateException();
+        }
+    }
+
+    abstract MapStoreIndexName getIndexName();
+
+    abstract MapStoreTableKey getIndexKey();
+
+    @Override
+    public String toString() {
+        final StringBuilder keyNameBuilder = new StringBuilder("?")
+            .append(getIndexKey().getHashField()).append("=").append(getIndexKey().getHashFieldType().getName());
+        getIndexKey().getRangeField().ifPresent(rangeField -> keyNameBuilder.append("&").append(rangeField)
+            .append("=").append(getIndexKey().getRangeFieldType().get().getName()));
+        final String keyName = keyNameBuilder.toString();
+
+        return getIndexName().toString() + keyName;
+    }
+}

--- a/mapstore-core/src/main/java/net/spals/appbuilder/mapstore/core/mapdb/MapDBMapStoreIndexPlugin.java
+++ b/mapstore-core/src/main/java/net/spals/appbuilder/mapstore/core/mapdb/MapDBMapStoreIndexPlugin.java
@@ -1,0 +1,151 @@
+package net.spals.appbuilder.mapstore.core.mapdb;
+
+import com.google.common.collect.ImmutableList;
+import com.google.inject.Inject;
+import net.spals.appbuilder.annotations.service.AutoBindInMap;
+import net.spals.appbuilder.mapstore.core.MapStore;
+import net.spals.appbuilder.mapstore.core.MapStoreIndexPlugin;
+import net.spals.appbuilder.mapstore.core.model.MapQueryOptions;
+import net.spals.appbuilder.mapstore.core.model.MapStoreIndexName;
+import net.spals.appbuilder.mapstore.core.model.MapStoreKey;
+import net.spals.appbuilder.mapstore.core.model.MapStoreTableKey;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.mapdb.BTreeMap;
+import org.mapdb.DB;
+import org.mapdb.MapModificationListener;
+import org.mapdb.Serializer;
+
+import javax.annotation.PreDestroy;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Function;
+
+import static net.spals.appbuilder.mapstore.core.mapdb.MapDBIndexMetadata.findIndexMetadata;
+import static net.spals.appbuilder.mapstore.core.mapdb.MapDBIndexMetadata.indexMetadata;
+import static net.spals.appbuilder.mapstore.core.mapdb.MapDBMapStorePlugin.createKeySerializer;
+
+/**
+ * @author tkral
+ */
+@AutoBindInMap(baseClass = MapStoreIndexPlugin.class, key = "mapDB")
+class MapDBMapStoreIndexPlugin implements MapStoreIndexPlugin {
+
+    private final DB mapDB;
+    private final MapStore mapStore;
+
+    @Inject
+    MapDBMapStoreIndexPlugin(
+        final DB mapDB,
+        final MapStore mapStore
+    ) {
+        this.mapDB = mapDB;
+        this.mapStore = mapStore;
+    }
+
+    @Override
+    @PreDestroy
+    public void close() {  }
+
+    @Override
+    public boolean createIndex(
+        final MapStoreIndexName indexName,
+        final MapStoreTableKey indexKey
+    ) {
+        // Create a new index table using the map store
+        final MapDBIndexMetadata indexMetadata = indexMetadata(indexName, indexKey);
+        final boolean createdIndex = mapStore.createTable(indexMetadata.toString(), indexKey);
+
+        if (createdIndex) {
+            // Copy all table records to the new index
+            final Function<byte[], Object[]> indexKeyFunction = indexKeyFunction(indexMetadata);
+            final BTreeMap<?, byte[]> table = mapDB.treeMap(indexName.getTableName())
+                .valueSerializer(Serializer.BYTE_ARRAY)
+                .open();
+            final BTreeMap<Object[], byte[]> index = mapDB.treeMap(indexMetadata.toString())
+                .keySerializer(createKeySerializer(indexKey.getHashFieldType(), indexKey.getRangeFieldType()))
+                .valueSerializer(Serializer.BYTE_ARRAY)
+                .open();
+
+            table.getValues().forEach((byte[] value) -> {
+                final Object[] newKey = indexKeyFunction.apply(value);
+                index.put(newKey, value);
+            });
+        }
+
+        return createdIndex;
+    }
+
+    @Override
+    public boolean dropIndex(final MapStoreIndexName indexName) {
+        return mapStore.dropTable(findIndexMetadata(mapDB, indexName).toString());
+    }
+
+    @Override
+    public Optional<Map<String, Object>> getItem(
+        final MapStoreIndexName indexName,
+        final MapStoreKey key
+    ) {
+        return mapStore.getItem(findIndexMetadata(mapDB, indexName).toString(), key);
+    }
+
+    @Override
+    public List<Map<String, Object>> getItems(
+        final MapStoreIndexName indexName,
+        final MapStoreKey key,
+        final MapQueryOptions options
+    ) {
+        return mapStore.getItems(findIndexMetadata(mapDB, indexName).toString(), key, options);
+    }
+
+    static Function<byte[], Object[]> indexKeyFunction(final MapDBIndexMetadata indexMetadata) {
+        return (byte[] value) -> {
+            final Map<String, Object> mapValue = MapDBMapStorePlugin.valueMapper().apply(value);
+            final ImmutableList.Builder<Object> keyValuesBuilder = ImmutableList.builder()
+                .add(mapValue.get(indexMetadata.getIndexKey().getHashField()));
+            indexMetadata.getIndexKey().getRangeField().ifPresent(rangeField ->
+                keyValuesBuilder.add(rangeField));
+
+            final List<Object> keyValues = keyValuesBuilder.build();
+            return keyValues.toArray(new Object[keyValues.size()]);
+        };
+    }
+
+    static class MapDBUpdateIndexListener implements MapModificationListener<Object[], byte[]> {
+
+        private final Function<byte[], Object[]> keyFunction;
+        private final BTreeMap<Object[], byte[]> index;
+
+        MapDBUpdateIndexListener(
+            final DB mapDB,
+            final MapDBIndexMetadata indexMetadata
+        ) {
+            this.keyFunction = MapDBMapStoreIndexPlugin.indexKeyFunction(indexMetadata);
+
+            this.index = mapDB.treeMap(indexMetadata.toString())
+                .keySerializer(createKeySerializer(
+                    indexMetadata.getIndexKey().getHashFieldType(),
+                    indexMetadata.getIndexKey().getRangeFieldType()
+                ))
+                .valueSerializer(Serializer.BYTE_ARRAY)
+                .open();
+        }
+
+        @Override
+        public void modify(
+            final @NotNull Object[] key,
+            final @Nullable byte[] oldValue,
+            final @Nullable byte[] newValue,
+            final boolean triggered
+        ) {
+            if (newValue == null) {
+                final Object[] oldKey = keyFunction.apply(oldValue);
+                index.remove(oldKey);
+            } else {
+                final Object[] newKey = keyFunction.apply(newValue);
+                index.put(newKey, newValue);
+            }
+        }
+    }
+}

--- a/mapstore-core/src/main/java/net/spals/appbuilder/mapstore/core/mapdb/MapDBMapStorePlugin.java
+++ b/mapstore-core/src/main/java/net/spals/appbuilder/mapstore/core/mapdb/MapDBMapStorePlugin.java
@@ -42,15 +42,17 @@ class MapDBMapStorePlugin implements MapStorePlugin {
     }
 
     @Override
-    public boolean createTable(final String tableName,
-                               final MapStoreTableKey tableKey) {
-        final SerializerArrayTuple storeKeySerializer = createKeySerializer(tableKey.getHashFieldType(),
-                tableKey.getRangeFieldType());
+    public boolean createTable(
+        final String tableName,
+        final MapStoreTableKey tableKey
+    ) {
+        final SerializerArrayTuple tableKeySerializer = createKeySerializer(tableKey.getHashFieldType(),
+            tableKey.getRangeFieldType());
 
         mapDB.treeMap(tableName)
-                .keySerializer(storeKeySerializer)
-                .valueSerializer(Serializer.BYTE_ARRAY)
-                .createOrOpen();
+            .keySerializer(tableKeySerializer)
+            .valueSerializer(Serializer.BYTE_ARRAY)
+            .createOrOpen();
         return true;
     }
 
@@ -64,8 +66,10 @@ class MapDBMapStorePlugin implements MapStorePlugin {
     }
 
     @Override
-    public void deleteItem(final String tableName,
-                           final MapStoreKey key) {
+    public void deleteItem(
+        final String tableName,
+        final MapStoreKey key
+    ) {
         final BTreeMap<Object[], byte[]> table = getTable(tableName, key);
         final Object[] keyArray = convertSimpleKeyToArray(key);
 
@@ -83,8 +87,10 @@ class MapDBMapStorePlugin implements MapStorePlugin {
     }
 
     @Override
-    public Optional<Map<String, Object>> getItem(final String tableName,
-                                                 final MapStoreKey key) {
+    public Optional<Map<String, Object>> getItem(
+        final String tableName,
+        final MapStoreKey key
+    ) {
         final BTreeMap<Object[], byte[]> table = getTable(tableName, key);
         final Object[] keyArray = convertSimpleKeyToArray(key);
 
@@ -93,9 +99,11 @@ class MapDBMapStorePlugin implements MapStorePlugin {
     }
 
     @Override
-    public List<Map<String, Object>> getItems(final String tableName,
-                                              final MapStoreKey key,
-                                              final MapQueryOptions options) {
+    public List<Map<String, Object>> getItems(
+        final String tableName,
+        final MapStoreKey key,
+        final MapQueryOptions options
+    ) {
         final BTreeMap<Object[], byte[]> table = getTable(tableName, key);
         Collection<byte[]> valueArrays = Collections.emptyList();
         final MapRangeOperator.Standard op = Standard.fromName(key.getRangeKey().getOperator().toString())
@@ -140,9 +148,11 @@ class MapDBMapStorePlugin implements MapStorePlugin {
     }
 
     @Override
-    public Map<String, Object> putItem(final String tableName,
-                                       final MapStoreKey key,
-                                       final Map<String, Object> payload) {
+    public Map<String, Object> putItem(
+        final String tableName,
+        final MapStoreKey key,
+        final Map<String, Object> payload
+    ) {
         final BTreeMap<Object[], byte[]> table = getTable(tableName, key);
         final Object[] keyArray = convertSimpleKeyToArray(key);
         final Map<String, Object> returnValue = new TreeMap<>(payload);
@@ -160,9 +170,11 @@ class MapDBMapStorePlugin implements MapStorePlugin {
     }
 
     @Override
-    public Map<String, Object> updateItem(final String tableName,
-                                          final MapStoreKey key,
-                                          final Map<String, Object> payload) {
+    public Map<String, Object> updateItem(
+        final String tableName,
+        final MapStoreKey key,
+        final Map<String, Object> payload
+    ) {
         final BTreeMap<Object[], byte[]> table = getTable(tableName, key);
         final Object[] keyArray = convertSimpleKeyToArray(key);
         // As a precondition, the item is guaranteed to be present
@@ -192,8 +204,10 @@ class MapDBMapStorePlugin implements MapStorePlugin {
     }
 
     @VisibleForTesting
-    SerializerArrayTuple createKeySerializer(final Class<?> hashFieldType,
-                                             final Optional<Class<? extends Comparable>> rangeFieldType) {
+    SerializerArrayTuple createKeySerializer(
+        final Class<?> hashFieldType,
+        final Optional<Class<? extends Comparable>> rangeFieldType
+    ) {
         final Serializer hashKeySerializer = SerializerUtils.serializerForClass(hashFieldType);
         final Optional<Serializer> rangeKeySerializer = rangeFieldType
                 .map(rangeType -> (Serializer) SerializerUtils.serializerForClass(rangeType));
@@ -203,8 +217,10 @@ class MapDBMapStorePlugin implements MapStorePlugin {
     }
 
     @VisibleForTesting
-    BTreeMap<Object[], byte[]> getTable(final String tableName,
-                                        final MapStoreKey key) {
+    BTreeMap<Object[], byte[]> getTable(
+        final String tableName,
+        final MapStoreKey key
+    ) {
         final SerializerArrayTuple storeKeySerializer = createKeySerializer(key.getHashValue().getClass(),
                 key.getRangeField().flatMap(rangeField -> {
                     final Optional<Comparable<?>> rangeValue = Optional.ofNullable(key.getRangeKey().getValue());
@@ -218,7 +234,10 @@ class MapDBMapStorePlugin implements MapStorePlugin {
     }
 
     @VisibleForTesting
-    Comparator<Map<String, Object>> valueComparator(final MapStoreKey key, final Order order) {
+    Comparator<Map<String, Object>> valueComparator(
+        final MapStoreKey key,
+        final Order order
+    ) {
         return (m1, m2) -> {
             // If there's no range key than order doesn't matter
             if (!key.getRangeField().isPresent()) {

--- a/mapstore-core/src/main/java/net/spals/appbuilder/mapstore/core/mapdb/MapDBMapStorePlugin.java
+++ b/mapstore-core/src/main/java/net/spals/appbuilder/mapstore/core/mapdb/MapDBMapStorePlugin.java
@@ -19,6 +19,7 @@ import org.mapdb.Serializer;
 import org.mapdb.serializer.SerializerArrayTuple;
 import org.mapdb.serializer.SerializerUtils;
 
+import javax.annotation.PreDestroy;
 import java.io.IOException;
 import java.util.*;
 import java.util.function.Function;
@@ -39,6 +40,12 @@ class MapDBMapStorePlugin implements MapStorePlugin {
     @Inject
     MapDBMapStorePlugin(final DB mapDB) {
         this.mapDB = mapDB;
+    }
+
+    @Override
+    @PreDestroy
+    public void close() {
+        mapDB.close();
     }
 
     @Override

--- a/mapstore-core/src/main/java/net/spals/appbuilder/mapstore/core/model/MapStoreIndexName.java
+++ b/mapstore-core/src/main/java/net/spals/appbuilder/mapstore/core/model/MapStoreIndexName.java
@@ -1,0 +1,26 @@
+package net.spals.appbuilder.mapstore.core.model;
+
+import com.google.auto.value.AutoValue;
+
+/**
+ * @author tkral
+ */
+@AutoValue
+public abstract class MapStoreIndexName {
+
+    public static MapStoreIndexName indexName(
+        final String tableName,
+        final String indexName
+    ) {
+        return new AutoValue_MapStoreIndexName(tableName, indexName);
+    }
+
+    public abstract String getTableName();
+
+    public abstract String getIndexName();
+
+    @Override
+    public String toString() {
+        return getTableName() + "." + getIndexName();
+    }
+}

--- a/mapstore-core/src/main/java/net/spals/appbuilder/mapstore/core/model/MapStoreIndexName.java
+++ b/mapstore-core/src/main/java/net/spals/appbuilder/mapstore/core/model/MapStoreIndexName.java
@@ -2,6 +2,8 @@ package net.spals.appbuilder.mapstore.core.model;
 
 import com.google.auto.value.AutoValue;
 
+import static com.google.common.base.Preconditions.checkNotNull;
+
 /**
  * @author tkral
  */
@@ -13,6 +15,11 @@ public abstract class MapStoreIndexName {
         final String indexName
     ) {
         return new AutoValue_MapStoreIndexName(tableName, indexName);
+    }
+
+    public static MapStoreIndexName fromString(final String indexNameStr) {
+        final String[] parsedIndexNameStr = checkNotNull(indexNameStr).split("\\.", 2);
+        return new AutoValue_MapStoreIndexName(parsedIndexNameStr[0], parsedIndexNameStr[1]);
     }
 
     public abstract String getTableName();

--- a/mapstore-dynamodb-test/src/test/scala/net/spals/appbuilder/mapstore/dynamodb/DynamoDBMapStoreIndexPluginIT.scala
+++ b/mapstore-dynamodb-test/src/test/scala/net/spals/appbuilder/mapstore/dynamodb/DynamoDBMapStoreIndexPluginIT.scala
@@ -1,0 +1,264 @@
+package net.spals.appbuilder.mapstore.dynamodb
+
+import java.util.Optional
+
+import com.google.common.collect.ImmutableMap
+import io.opentracing.mock.{MockSpan, MockTracer}
+import net.spals.appbuilder.mapstore.core.model.MapQueryOptions.defaultOptions
+import net.spals.appbuilder.mapstore.core.model.MapStoreIndexName.indexName
+import net.spals.appbuilder.mapstore.core.model.SingleValueMapRangeKey.{equalTo => range_equalTo}
+import net.spals.appbuilder.mapstore.core.model.{MapStoreIndexName, MapStoreKey, MapStoreTableKey}
+import net.spals.appbuilder.mapstore.dynamodb.DynamoDBSpanMatcher.dynamoDBSpan
+import org.hamcrest.Matcher
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers._
+import org.slf4j.LoggerFactory
+import org.testng.annotations._
+
+import scala.collection.JavaConverters._
+
+/**
+  * Integration tests for [[DynamoDBMapStoreIndexPlugin]].
+  *
+  * @author tkral
+  */
+class DynamoDBMapStoreIndexPluginIT {
+  private val LOGGER = LoggerFactory.getLogger(classOf[DynamoDBMapStoreIndexPluginIT])
+
+  private val dynamoDBEndpoint = s"http://${System.getenv("DYNAMODB_IP")}:${System.getenv("DYNAMODB_PORT")}"
+  private val dynamoDBTracer = new MockTracer()
+  private lazy val dynamoDBClient = {
+    val dynamoDBClientProvider = new DynamoDBClientProvider(dynamoDBTracer)
+    dynamoDBClientProvider.awsAccessKeyId = "DUMMY"
+    dynamoDBClientProvider.awsSecretKey = "DUMMY"
+    dynamoDBClientProvider.endpoint = dynamoDBEndpoint
+
+    LOGGER.info(s"Connecting to dynamoDB instance at ${dynamoDBClientProvider.endpoint}")
+    dynamoDBClientProvider.get()
+  }
+
+  private lazy val mapStorePlugin = {
+    val plugin = new DynamoDBMapStorePlugin(dynamoDBClient)
+    plugin.synchronousDDL = true
+    plugin
+  }
+  private lazy val mapStoreIndexPlugin = {
+    val plugin = new DynamoDBMapStoreIndexPlugin(dynamoDBClient)
+    plugin.synchronousDDL = true
+    plugin
+  }
+
+  private val hashIndexName = indexName("DynamoDBMapStoreIndexPluginIT_hashTable", "hashIndex")
+  private val hashTableKey = new MapStoreTableKey.Builder()
+    .setHash("tableHashField", classOf[String])
+    .build
+  private val hashIndexKey = new MapStoreTableKey.Builder()
+    .setHash("indexHashField", classOf[String])
+    .build
+
+  private val rangeIndexName = indexName("DynamoDBMapStoreIndexPluginIT_rangeTable", "rangeIndex")
+  private val rangeTableKey = new MapStoreTableKey.Builder()
+    .setHash("tableHashField", classOf[String])
+    .setRange("tableRangeField", classOf[String])
+    .build
+  private val rangeIndexKey = new MapStoreTableKey.Builder()
+    .setHash("indexHashField", classOf[String])
+    .setRange("indexRangeField", classOf[String])
+    .build
+
+  @BeforeClass def createTablesAndIndexes() {
+    mapStorePlugin.createTable(hashIndexName.getTableName, hashTableKey)
+    mapStoreIndexPlugin.createIndex(hashIndexName, hashIndexKey)
+
+    mapStorePlugin.createTable(rangeIndexName.getTableName, rangeTableKey)
+    mapStoreIndexPlugin.createIndex(rangeIndexName, rangeIndexKey)
+  }
+
+  @BeforeMethod def resetTracer() {
+    dynamoDBTracer.reset()
+  }
+
+  @AfterClass(alwaysRun = true) def tearDownClass() {
+    mapStoreIndexPlugin.dropIndex(hashIndexName)
+    mapStoreIndexPlugin.dropIndex(rangeIndexName)
+
+    mapStorePlugin.dropTable(hashIndexName.getTableName)
+    mapStorePlugin.dropTable(rangeIndexName.getTableName)
+
+    mapStoreIndexPlugin.close()
+    mapStorePlugin.close()
+  }
+
+  @DataProvider def emptyGetProvider(): Array[Array[AnyRef]] = {
+    Array(
+      // Case: Hash-only key
+      Array(hashIndexName,
+        new MapStoreKey.Builder().setHash("indexHashField", "deadbeef").build),
+      // Case: Hash and range key
+      Array(rangeIndexName,
+        new MapStoreKey.Builder().setHash("indexHashField", "deadbeef")
+          .setRange("indexRangeField", range_equalTo[String]("deadbeef")).build)
+    )
+  }
+
+  @Test(
+    dataProvider = "emptyGetProvider",
+    groups = Array("DynamoDBMapStoreIndexPluginIT.empty")
+  )
+  def testEmptyGetItem(
+    indexName: MapStoreIndexName,
+    storeKey: MapStoreKey
+  ) {
+    assertThat(mapStoreIndexPlugin.getItem(indexName, storeKey), is(Optional.empty[java.util.Map[String, AnyRef]]))
+    assertThat(dynamoDBTracer.finishedSpans(), contains[MockSpan](dynamoDBSpan(dynamoDBEndpoint, "POST")))
+  }
+
+  @Test(
+    dataProvider = "emptyGetProvider",
+    groups = Array("DynamoDBMapStoreIndexPluginIT.empty")
+  )
+  def testEmptyGetItems(
+    indexName: MapStoreIndexName,
+    storeKey: MapStoreKey
+  ) {
+    assertThat(mapStoreIndexPlugin.getItems(indexName, storeKey, defaultOptions()), empty[java.util.Map[String, AnyRef]])
+    assertThat(dynamoDBTracer.finishedSpans(), contains[MockSpan](dynamoDBSpan(dynamoDBEndpoint, "POST")))
+  }
+
+  @Test(
+    groups = Array("DynamoDBMapStoreIndexPluginIT.get"),
+    dependsOnGroups = Array("DynamoDBMapStoreIndexPluginIT.empty")
+  )
+  def testGetItemHashOnly() {
+    val tableItemKey = new MapStoreKey.Builder().setHash("tableHashField", "table").build
+    mapStorePlugin.putItem(hashIndexName.getTableName, tableItemKey,
+      Map("indexHashField" -> "index").asJava.asInstanceOf[java.util.Map[String, AnyRef]])
+
+    val indexItemKey = new MapStoreKey.Builder().setHash("indexHashField", "index").build
+    val indexItem = mapStoreIndexPlugin.getItem(hashIndexName, indexItemKey)
+    assertThat(indexItem, not(Optional.empty[java.util.Map[String, AnyRef]]))
+
+    val itemMatcher: Matcher[java.util.Map[String, AnyRef]] =
+      equalTo(ImmutableMap.of("tableHashField", "table", "indexHashField", "index"))
+    assertThat(indexItem.get, itemMatcher)
+    assertThat(dynamoDBTracer.finishedSpans(), contains[MockSpan](
+      dynamoDBSpan(dynamoDBEndpoint, "POST"),
+      dynamoDBSpan(dynamoDBEndpoint, "POST")
+    ))
+  }
+
+  @Test(
+    groups = Array("DynamoDBMapStoreIndexPluginIT.get"),
+    dependsOnGroups = Array("DynamoDBMapStoreIndexPluginIT.empty")
+  )
+  def testGetItemHashRange() {
+    val tableItemKey = new MapStoreKey.Builder().setHash("tableHashField", "table")
+      .setRange("tableRangeField", range_equalTo[String]("1")).build
+    mapStorePlugin.putItem(rangeIndexName.getTableName, tableItemKey,
+      Map("indexHashField" -> "index", "indexRangeField" -> "11").asJava.asInstanceOf[java.util.Map[String, AnyRef]])
+
+    val indexItemKey = new MapStoreKey.Builder().setHash("indexHashField", "index")
+      .setRange("indexRangeField", range_equalTo[String]("11")).build
+    val indexItem = mapStoreIndexPlugin.getItem(rangeIndexName, indexItemKey)
+    assertThat(indexItem, not(Optional.empty[java.util.Map[String, AnyRef]]))
+
+    val itemMatcher: Matcher[java.util.Map[String, AnyRef]] =
+      equalTo(ImmutableMap.of(
+        "tableHashField", "table", "tableRangeField", "1",
+        "indexHashField", "index", "indexRangeField", "11"
+      ))
+    assertThat(indexItem.get, itemMatcher)
+    assertThat(dynamoDBTracer.finishedSpans(), contains[MockSpan](
+      dynamoDBSpan(dynamoDBEndpoint, "POST"),
+      dynamoDBSpan(dynamoDBEndpoint, "POST")
+    ))
+  }
+
+  @Test(
+    groups = Array("DynamoDBMapStoreIndexPluginIT.update"),
+    dependsOnGroups = Array("DynamoDBMapStoreIndexPluginIT.get")
+  )
+  def testUpdateItemHashOnly() {
+    val tableItemKey = new MapStoreKey.Builder().setHash("tableHashField", "table").build
+    mapStorePlugin.updateItem(hashIndexName.getTableName, tableItemKey,
+      Map("key" -> "value").asJava.asInstanceOf[java.util.Map[String, AnyRef]])
+
+    val indexItemKey = new MapStoreKey.Builder().setHash("indexHashField", "index").build
+    val indexItem = mapStoreIndexPlugin.getItem(hashIndexName, indexItemKey)
+    assertThat(indexItem, not(Optional.empty[java.util.Map[String, AnyRef]]))
+
+    val itemMatcher: Matcher[java.util.Map[String, AnyRef]] =
+      equalTo(ImmutableMap.of("tableHashField", "table", "indexHashField", "index", "key", "value"))
+    assertThat(indexItem.get, itemMatcher)
+    assertThat(dynamoDBTracer.finishedSpans(), contains[MockSpan](
+      dynamoDBSpan(dynamoDBEndpoint, "POST"),
+      dynamoDBSpan(dynamoDBEndpoint, "POST"),
+      dynamoDBSpan(dynamoDBEndpoint, "POST")
+    ))
+  }
+
+  @Test(
+    groups = Array("DynamoDBMapStoreIndexPluginIT.update"),
+    dependsOnGroups = Array("DynamoDBMapStoreIndexPluginIT.get")
+  )
+  def testUpdateItemHashRange() {
+    val tableItemKey = new MapStoreKey.Builder().setHash("tableHashField", "table")
+      .setRange("tableRangeField", range_equalTo[String]("1")).build
+    mapStorePlugin.updateItem(rangeIndexName.getTableName, tableItemKey,
+      Map("key" -> "value").asJava.asInstanceOf[java.util.Map[String, AnyRef]])
+
+    val indexItemKey = new MapStoreKey.Builder().setHash("indexHashField", "index")
+      .setRange("indexRangeField", range_equalTo[String]("11")).build
+    val indexItem = mapStoreIndexPlugin.getItem(rangeIndexName, indexItemKey)
+    assertThat(indexItem, not(Optional.empty[java.util.Map[String, AnyRef]]))
+
+    val itemMatcher: Matcher[java.util.Map[String, AnyRef]] =
+      equalTo(ImmutableMap.of(
+        "tableHashField", "table", "tableRangeField", "1",
+        "indexHashField", "index", "indexRangeField", "11",
+        "key", "value"
+      ))
+    assertThat(indexItem.get, itemMatcher)
+    assertThat(dynamoDBTracer.finishedSpans(), contains[MockSpan](
+      dynamoDBSpan(dynamoDBEndpoint, "POST"),
+      dynamoDBSpan(dynamoDBEndpoint, "POST"),
+      dynamoDBSpan(dynamoDBEndpoint, "POST")
+    ))
+  }
+
+  @Test(
+    groups = Array("DynamoDBMapStoreIndexPluginIT.delete"),
+    dependsOnGroups = Array("DynamoDBMapStoreIndexPluginIT.update")
+  )
+  def testDeleteItemHashOnly() {
+    val tableItemKey = new MapStoreKey.Builder().setHash("tableHashField", "table").build
+    mapStorePlugin.deleteItem(hashIndexName.getTableName, tableItemKey)
+
+    val indexItemKey = new MapStoreKey.Builder().setHash("indexHashField", "index").build
+    val indexItem = mapStoreIndexPlugin.getItem(hashIndexName, indexItemKey)
+    assertThat(indexItem, is(Optional.empty[java.util.Map[String, AnyRef]]))
+    assertThat(dynamoDBTracer.finishedSpans(), contains[MockSpan](
+      dynamoDBSpan(dynamoDBEndpoint, "POST"),
+      dynamoDBSpan(dynamoDBEndpoint, "POST")
+    ))
+  }
+
+  @Test(
+    groups = Array("DynamoDBMapStoreIndexPluginIT.delete"),
+    dependsOnGroups = Array("DynamoDBMapStoreIndexPluginIT.update")
+  )
+  def testDeleteItemHashRange() {
+    val tableItemKey = new MapStoreKey.Builder().setHash("tableHashField", "table")
+      .setRange("tableRangeField", range_equalTo[String]("1")).build
+    mapStorePlugin.deleteItem(rangeIndexName.getTableName, tableItemKey)
+
+    val indexItemKey = new MapStoreKey.Builder().setHash("indexHashField", "index")
+      .setRange("indexRangeField", range_equalTo[String]("11")).build
+    val indexItem = mapStoreIndexPlugin.getItem(rangeIndexName, indexItemKey)
+    assertThat(indexItem, is(Optional.empty[java.util.Map[String, AnyRef]]))
+    assertThat(dynamoDBTracer.finishedSpans(), contains[MockSpan](
+      dynamoDBSpan(dynamoDBEndpoint, "POST"),
+      dynamoDBSpan(dynamoDBEndpoint, "POST")
+    ))
+  }
+}

--- a/mapstore-dynamodb-test/src/test/scala/net/spals/appbuilder/mapstore/dynamodb/DynamoDBMapStoreUtilTest.scala
+++ b/mapstore-dynamodb-test/src/test/scala/net/spals/appbuilder/mapstore/dynamodb/DynamoDBMapStoreUtilTest.scala
@@ -1,10 +1,9 @@
 package net.spals.appbuilder.mapstore.dynamodb
 
-import com.amazonaws.services.dynamodbv2.AmazonDynamoDB
 import com.amazonaws.services.dynamodbv2.model.ScalarAttributeType
+import net.spals.appbuilder.mapstore.dynamodb.DynamoDBMapStoreUtil.createAttributeType
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.is
-import org.mockito.Mockito.mock
 import org.testng.annotations.{DataProvider, Test}
 
 /**
@@ -12,7 +11,7 @@ import org.testng.annotations.{DataProvider, Test}
   *
   * @author tkral
   */
-class DynamoDBMapStorePluginTest {
+class DynamoDBMapStoreUtilTest {
 
   @DataProvider def createAttributeTypeProvider(): Array[Array[AnyRef]] = {
     Array(
@@ -42,7 +41,6 @@ class DynamoDBMapStorePluginTest {
 
   @Test(dataProvider = "createAttributeTypeProvider")
   def testCreateAttributeType(fieldType: Class[_], expectedAttributeType: ScalarAttributeType) {
-    val dynamoDBMapStorePlugin = new DynamoDBMapStorePlugin(mock(classOf[AmazonDynamoDB]))
-    assertThat(dynamoDBMapStorePlugin.createAttributeType(fieldType), is(expectedAttributeType))
+    assertThat(createAttributeType(fieldType), is(expectedAttributeType))
   }
 }

--- a/mapstore-dynamodb-test/src/test/scala/net/spals/appbuilder/mapstore/dynamodb/DynamoDBSpanMatcher.scala
+++ b/mapstore-dynamodb-test/src/test/scala/net/spals/appbuilder/mapstore/dynamodb/DynamoDBSpanMatcher.scala
@@ -1,0 +1,38 @@
+package net.spals.appbuilder.mapstore.dynamodb
+
+import io.opentracing.mock.MockSpan
+import org.hamcrest.Matchers.hasEntry
+import org.hamcrest.{Description, TypeSafeMatcher}
+
+/**
+  * A Hamcrest [[org.hamcrest.Matcher]] used
+  * to match tracing spans specific to DynamoDB.
+  *
+  * @author tkral
+  */
+private[dynamodb] object DynamoDBSpanMatcher {
+
+  def dynamoDBSpan(url: String, method: String): DynamoDBSpanMatcher =
+    DynamoDBSpanMatcher(url, method)
+}
+
+private[dynamodb] case class DynamoDBSpanMatcher(
+  url: String,
+  method: String
+) extends TypeSafeMatcher[MockSpan] {
+
+  override def matchesSafely(mockSpan: MockSpan): Boolean = {
+    hasEntry[String, AnyRef]("component", "java-aws-sdk").matches(mockSpan.tags()) &&
+      hasEntry[String, AnyRef]("http.method", method).matches(mockSpan.tags()) &&
+      hasEntry[String, AnyRef]("http.url", url).matches(mockSpan.tags()) &&
+      hasEntry[String, AnyRef]("span.kind", "client").matches(mockSpan.tags()) &&
+      "AmazonDynamoDBv2".equals(mockSpan.operationName())
+  }
+
+  override def describeTo(description: Description): Unit = {
+    description.appendText("a DynamoDB span tagged with method ")
+    description.appendText(method)
+    description.appendText(" and url ")
+    description.appendText(url)
+  }
+}

--- a/mapstore-dynamodb/src/main/scala/net/spals/appbuilder/mapstore/dynamodb/DynamoDBMapStoreIndexPlugin.scala
+++ b/mapstore-dynamodb/src/main/scala/net/spals/appbuilder/mapstore/dynamodb/DynamoDBMapStoreIndexPlugin.scala
@@ -1,0 +1,124 @@
+package net.spals.appbuilder.mapstore.dynamodb
+
+import java.util
+import java.util.Optional
+import javax.annotation.PreDestroy
+import javax.validation.constraints.NotNull
+
+import com.amazonaws.services.dynamodbv2.AmazonDynamoDB
+import com.amazonaws.services.dynamodbv2.document.DynamoDB
+import com.amazonaws.services.dynamodbv2.model._
+import com.google.inject.Inject
+import com.netflix.governator.annotations.Configuration
+import net.spals.appbuilder.annotations.service.AutoBindInMap
+import net.spals.appbuilder.mapstore.core.MapStoreIndexPlugin
+import net.spals.appbuilder.mapstore.core.model.{MapQueryOptions, MapStoreIndexName, MapStoreKey, MapStoreTableKey}
+import net.spals.appbuilder.mapstore.dynamodb.DynamoDBMapStoreUtil.{createAttributeType, createQuerySpec}
+
+import scala.collection.JavaConverters._
+import scala.compat.java8.OptionConverters._
+
+/**
+  * Implementation of [[MapStoreIndexPlugin]] which
+  * uses AWS DynamoDB.
+  *
+  * @author tkral
+  */
+@AutoBindInMap(baseClass = classOf[MapStoreIndexPlugin], key = "dynamoDB")
+private[dynamodb] class DynamoDBMapStoreIndexPlugin @Inject() (
+  dynamoDBClient: AmazonDynamoDB
+) extends MapStoreIndexPlugin {
+
+  @NotNull
+  @Configuration("mapStore.dynamoDB.synchronousDDL")
+  private[dynamodb] var synchronousDDL: Boolean = false
+
+  private val dynamoDB = new DynamoDB(dynamoDBClient)
+
+  @PreDestroy
+  override def close() = dynamoDB.shutdown()
+
+  override def createIndex(
+    indexName: MapStoreIndexName,
+    indexKey: MapStoreTableKey
+  ): Boolean = {
+    // Add hash key information to the create index request
+    val hashKeyAttrDef = new AttributeDefinition().withAttributeName(indexKey.getHashField)
+      .withAttributeType(createAttributeType(indexKey.getHashFieldType))
+    val hashKeySchema: KeySchemaElement = new KeySchemaElement(indexKey.getHashField, KeyType.HASH)
+
+    val createGSIAction = new CreateGlobalSecondaryIndexAction()
+      .withIndexName(indexName.getIndexName)
+      .withProjection(new Projection().withProjectionType(ProjectionType.ALL))
+      .withKeySchema(hashKeySchema)
+
+    val rangeKeyAttrDefOpt = indexKey.getRangeField.asScala.map(rangeField =>
+      new AttributeDefinition().withAttributeName(rangeField)
+        .withAttributeType(createAttributeType(indexKey.getRangeFieldType.get())))
+    rangeKeyAttrDefOpt.foreach(rangeKey => {
+      val rangeKeySchema = new KeySchemaElement(rangeKey.getAttributeName, KeyType.RANGE)
+      createGSIAction.withKeySchema(rangeKeySchema)
+    })
+
+    // Add minimal provisioned throughput to the index
+    val provisionedThroughput = new ProvisionedThroughput().withReadCapacityUnits(1L).withWriteCapacityUnits(1L)
+    createGSIAction.withProvisionedThroughput(provisionedThroughput)
+
+    val table = dynamoDB.getTable(indexName.getTableName)
+    val index = rangeKeyAttrDefOpt match {
+      case Some(rangeKeyAttrDef) => table.createGSI(createGSIAction, hashKeyAttrDef, rangeKeyAttrDef)
+      case None => table.createGSI(createGSIAction, hashKeyAttrDef)
+    }
+
+    synchronousDDL match {
+      case false => true
+      case true => {
+        val indexDescription = index.waitForActive()
+        TableStatus.ACTIVE.toString.equals(indexDescription.getTableStatus)
+      }
+    }
+  }
+
+  override def dropIndex(indexName: MapStoreIndexName): Boolean = {
+    val table = dynamoDB.getTable(indexName.getTableName)
+    val index = table.getIndex(indexName.getIndexName)
+    index.deleteGSI()
+
+    synchronousDDL match {
+      case false => true
+      case true => {
+        val indexDescription = index.waitForDelete()
+        TableStatus.ACTIVE.toString.equals(indexDescription.getTableStatus)
+      }
+    }
+    true
+  }
+
+  override def getItem(
+    indexName: MapStoreIndexName,
+    key: MapStoreKey
+  ): Optional[util.Map[String, AnyRef]] = {
+    val table = dynamoDB.getTable(indexName.getTableName)
+    val index = table.getIndex(indexName.getIndexName)
+
+    val singleOptions = new MapQueryOptions.Builder().setLimit(1).build()
+    val querySpec = createQuerySpec(key, singleOptions)
+
+    Option(index.query(querySpec).asScala.map(_.asMap()).toList)
+      .filter(!_.isEmpty)
+      .map(_.head)
+      .asJava
+  }
+
+  override def getItems(
+    indexName: MapStoreIndexName,
+    key: MapStoreKey,
+    options: MapQueryOptions
+  ): util.List[util.Map[String, AnyRef]] = {
+    val table = dynamoDB.getTable(indexName.getTableName)
+    val index = table.getIndex(indexName.getIndexName)
+    val querySpec = createQuerySpec(key, options)
+
+    index.query(querySpec).asScala.map(_.asMap()).toList.asJava
+  }
+}

--- a/mapstore-dynamodb/src/main/scala/net/spals/appbuilder/mapstore/dynamodb/DynamoDBMapStorePlugin.scala
+++ b/mapstore-dynamodb/src/main/scala/net/spals/appbuilder/mapstore/dynamodb/DynamoDBMapStorePlugin.scala
@@ -30,7 +30,7 @@ import scala.compat.java8.OptionConverters._
   */
 @AutoBindInMap(baseClass = classOf[MapStorePlugin], key = "dynamoDB")
 private[dynamodb] class DynamoDBMapStorePlugin @Inject() (dynamoDBClient: AmazonDynamoDB)
-  extends MapStorePlugin with Closeable {
+  extends MapStorePlugin {
   private val LOGGER = LoggerFactory.getLogger(classOf[DynamoDBMapStorePlugin])
 
   private val dynamoDB = new DynamoDB(dynamoDBClient)

--- a/mapstore-dynamodb/src/main/scala/net/spals/appbuilder/mapstore/dynamodb/DynamoDBMapStorePlugin.scala
+++ b/mapstore-dynamodb/src/main/scala/net/spals/appbuilder/mapstore/dynamodb/DynamoDBMapStorePlugin.scala
@@ -1,22 +1,21 @@
 package net.spals.appbuilder.mapstore.dynamodb
 
-import java.io.Closeable
-import java.util.{Collections, Optional}
+import java.util.Optional
 import javax.annotation.PreDestroy
+import javax.validation.constraints.NotNull
 
 import com.amazonaws.services.dynamodbv2.AmazonDynamoDB
 import com.amazonaws.services.dynamodbv2.document._
-import com.amazonaws.services.dynamodbv2.document.spec.{QuerySpec, ScanSpec, UpdateTableSpec}
+import com.amazonaws.services.dynamodbv2.document.spec.ScanSpec
 import com.amazonaws.services.dynamodbv2.model._
 import com.amazonaws.services.dynamodbv2.util.TableUtils
-import com.google.common.annotations.VisibleForTesting
 import com.google.inject.Inject
+import com.netflix.governator.annotations.Configuration
 import net.spals.appbuilder.annotations.service.AutoBindInMap
 import net.spals.appbuilder.mapstore.core.MapStorePlugin
 import net.spals.appbuilder.mapstore.core.MapStorePlugin.stripKey
-import net.spals.appbuilder.mapstore.core.model.MapRangeOperator.{Extended, Standard}
-import net.spals.appbuilder.mapstore.core.model.TwoValueMapRangeKey.TwoValueHolder
 import net.spals.appbuilder.mapstore.core.model.{MapQueryOptions, MapStoreKey, MapStoreTableKey}
+import net.spals.appbuilder.mapstore.dynamodb.DynamoDBMapStoreUtil.{createAttributeType, createPrimaryKey, createQuerySpec}
 import org.slf4j.LoggerFactory
 
 import scala.collection.JavaConverters._
@@ -29,14 +28,19 @@ import scala.compat.java8.OptionConverters._
   * @author tkral
   */
 @AutoBindInMap(baseClass = classOf[MapStorePlugin], key = "dynamoDB")
-private[dynamodb] class DynamoDBMapStorePlugin @Inject() (dynamoDBClient: AmazonDynamoDB)
-  extends MapStorePlugin {
+private[dynamodb] class DynamoDBMapStorePlugin @Inject() (
+  dynamoDBClient: AmazonDynamoDB
+) extends MapStorePlugin {
   private val LOGGER = LoggerFactory.getLogger(classOf[DynamoDBMapStorePlugin])
+
+  @NotNull
+  @Configuration("mapStore.dynamoDB.synchronousDDL")
+  private[dynamodb] var synchronousDDL: Boolean = false
 
   private val dynamoDB = new DynamoDB(dynamoDBClient)
 
   @PreDestroy
-  override def close() = dynamoDB.shutdown()
+  override def close() = dynamoDBClient.shutdown()
 
   override def createTable(
     tableName: String,
@@ -68,16 +72,37 @@ private[dynamodb] class DynamoDBMapStorePlugin @Inject() (dynamoDBClient: Amazon
     try {
       TableUtils.createTableIfNotExists(dynamoDBClient, createTableRequest)
       // If we fall through the create-if-not-exists without error
-      // then the table exists so we'll return true
-      true
+      // then the table exists
+      synchronousDDL match {
+        case false => true
+        case true => {
+          val tableDescription = dynamoDB.getTable(tableName).waitForActive()
+          TableStatus.ACTIVE.toString.equals(tableDescription.getTableStatus)
+        }
+      }
     } catch {
       case _: RuntimeException => false
     }
   }
 
   override def dropTable(tableName: String): Boolean = {
+    val table = dynamoDB.getTable(tableName)
+
     val deleteTableRequest = new DeleteTableRequest().withTableName(tableName)
-    TableUtils.deleteTableIfExists(dynamoDBClient, deleteTableRequest)
+    try {
+      TableUtils.deleteTableIfExists(dynamoDBClient, deleteTableRequest)
+      // if we fall through the delete-if-exists without error
+      // then the table not longer exists
+      synchronousDDL match {
+        case false => true
+        case true => {
+          table.waitForDelete()
+          true
+        }
+      }
+    } catch {
+      case _: RuntimeException => false
+    }
   }
 
   override def deleteItem(
@@ -121,11 +146,7 @@ private[dynamodb] class DynamoDBMapStorePlugin @Inject() (dynamoDBClient: Amazon
     options: MapQueryOptions
   ): java.util.List[java.util.Map[String, AnyRef]] = {
     val table = dynamoDB.getTable(tableName)
-    val querySpec = new QuerySpec().withHashKey(key.getHashField, key.getHashValue)
-    createRangeKeyCondition(key).foreach(rangeKeyCondition => querySpec.withRangeKeyCondition(rangeKeyCondition))
-
-    querySpec.withScanIndexForward(options.getOrder == MapQueryOptions.Order.ASC)
-    options.getLimit.asScala.foreach(limit => querySpec.withMaxResultSize(limit))
+    val querySpec = createQuerySpec(key, options)
 
     table.query(querySpec).asScala.map(_.asMap()).toList.asJava
   }
@@ -176,50 +197,5 @@ private[dynamodb] class DynamoDBMapStorePlugin @Inject() (dynamoDBClient: Amazon
 
     Option(updateItemOutcome.getItem).map(_.asMap())
       .getOrElse(table.getItem(primaryKey).asMap())
-  }
-
-  @VisibleForTesting
-  private[dynamodb] def createAttributeType(fieldType: Class[_]): ScalarAttributeType = {
-    fieldType match {
-      case booleanType if booleanType.equals(classOf[Boolean]) => ScalarAttributeType.B
-      case byteType if byteType.equals(classOf[Byte]) => ScalarAttributeType.N
-      case doubleType if doubleType.equals(classOf[Double]) => ScalarAttributeType.N
-      case floatType if floatType.equals(classOf[Float]) => ScalarAttributeType.N
-      case intType if intType.equals(classOf[Int]) => ScalarAttributeType.N
-      case javaBooleanType if javaBooleanType.equals(classOf[java.lang.Boolean]) => ScalarAttributeType.B
-      case javaNumberType if classOf[java.lang.Number].isAssignableFrom(javaNumberType) => ScalarAttributeType.N
-      case longType if longType.equals(classOf[Long]) => ScalarAttributeType.N
-      case shortType if shortType.equals(classOf[Short]) => ScalarAttributeType.N
-      case _ => ScalarAttributeType.S
-    }
-  }
-
-  @VisibleForTesting
-  private[dynamodb] def createPrimaryKey(key: MapStoreKey): PrimaryKey = {
-    key.getRangeField.asScala
-      .map(rangeField => new PrimaryKey(key.getHashField, key.getHashValue, rangeField, key.getRangeKey.getValue))
-      .getOrElse(new PrimaryKey(key.getHashField, key.getHashValue))
-  }
-
-  @VisibleForTesting
-  private[dynamodb] def createRangeKeyCondition(key: MapStoreKey): Option[RangeKeyCondition] = {
-    key.getRangeField.asScala.flatMap(rangeField => {
-      val rangeKeyCondition = new RangeKeyCondition(rangeField)
-      (key.getRangeKey.getOperator, key.getRangeKey.getValue) match {
-        case (Standard.ALL, _) => Option.empty[RangeKeyCondition]
-        case (Standard.NONE, _) => Option.empty[RangeKeyCondition]
-        case (Standard.BETWEEN, rValue) =>
-          Option(rangeKeyCondition.between(rValue.asInstanceOf[TwoValueHolder[_]].getValue1,
-                 rValue.asInstanceOf[TwoValueHolder[_]].getValue2))
-        case (Standard.EQUAL_TO, rValue) => Option(rangeKeyCondition.eq(rValue))
-        case (Standard.GREATER_THAN, rValue) => Option(rangeKeyCondition.gt(rValue))
-        case (Standard.GREATER_THAN_OR_EQUAL_TO, rValue) => Option(rangeKeyCondition.ge(rValue))
-        case (Standard.LESS_THAN, rValue) => Option(rangeKeyCondition.lt(rValue))
-        case (Standard.LESS_THAN_OR_EQUAL_TO, rValue) => Option(rangeKeyCondition.le(rValue))
-        case (Extended.STARTS_WITH, rValue) => Option(rangeKeyCondition.beginsWith(rValue.asInstanceOf[String]))
-        case (operator, _) =>
-          throw new IllegalArgumentException(s"DynamoDB cannot support the operator $operator")
-      }
-    })
   }
 }

--- a/mapstore-dynamodb/src/main/scala/net/spals/appbuilder/mapstore/dynamodb/DynamoDBMapStorePlugin.scala
+++ b/mapstore-dynamodb/src/main/scala/net/spals/appbuilder/mapstore/dynamodb/DynamoDBMapStorePlugin.scala
@@ -1,12 +1,12 @@
 package net.spals.appbuilder.mapstore.dynamodb
 
 import java.io.Closeable
-import java.util.Optional
+import java.util.{Collections, Optional}
 import javax.annotation.PreDestroy
 
 import com.amazonaws.services.dynamodbv2.AmazonDynamoDB
 import com.amazonaws.services.dynamodbv2.document._
-import com.amazonaws.services.dynamodbv2.document.spec.{QuerySpec, ScanSpec}
+import com.amazonaws.services.dynamodbv2.document.spec.{QuerySpec, ScanSpec, UpdateTableSpec}
 import com.amazonaws.services.dynamodbv2.model._
 import com.amazonaws.services.dynamodbv2.util.TableUtils
 import com.google.common.annotations.VisibleForTesting
@@ -38,8 +38,10 @@ private[dynamodb] class DynamoDBMapStorePlugin @Inject() (dynamoDBClient: Amazon
   @PreDestroy
   override def close() = dynamoDB.shutdown()
 
-  override def createTable(tableName: String,
-                           tableKey: MapStoreTableKey): Boolean = {
+  override def createTable(
+    tableName: String,
+    tableKey: MapStoreTableKey
+  ): Boolean = {
     // Add hash key information to the create table request
     val hashKeyAttrDef = new AttributeDefinition().withAttributeName(tableKey.getHashField)
       .withAttributeType(createAttributeType(tableKey.getHashFieldType))
@@ -78,8 +80,10 @@ private[dynamodb] class DynamoDBMapStorePlugin @Inject() (dynamoDBClient: Amazon
     TableUtils.deleteTableIfExists(dynamoDBClient, deleteTableRequest)
   }
 
-  override def deleteItem(tableName: String,
-                          key: MapStoreKey): Unit = {
+  override def deleteItem(
+    tableName: String,
+    key: MapStoreKey
+  ): Unit = {
     val table = dynamoDB.getTable(tableName)
     val primaryKey = createPrimaryKey(key)
 
@@ -95,8 +99,10 @@ private[dynamodb] class DynamoDBMapStorePlugin @Inject() (dynamoDBClient: Amazon
     table.scan(new ScanSpec).asScala.map(_.asMap()).toList.asJava
   }
 
-  override def getItem(tableName: String,
-                       key: MapStoreKey): Optional[java.util.Map[String, AnyRef]] = {
+  override def getItem(
+    tableName: String,
+    key: MapStoreKey
+  ): Optional[java.util.Map[String, AnyRef]] = {
     val table = dynamoDB.getTable(tableName)
     val primaryKey = createPrimaryKey(key)
 
@@ -109,9 +115,11 @@ private[dynamodb] class DynamoDBMapStorePlugin @Inject() (dynamoDBClient: Amazon
     Option(getItemOutcome.getItem).map(_.asMap()).asJava
   }
 
-  override def getItems(tableName: String,
-                        key: MapStoreKey,
-                        options: MapQueryOptions): java.util.List[java.util.Map[String, AnyRef]] = {
+  override def getItems(
+    tableName: String,
+    key: MapStoreKey,
+    options: MapQueryOptions
+  ): java.util.List[java.util.Map[String, AnyRef]] = {
     val table = dynamoDB.getTable(tableName)
     val querySpec = new QuerySpec().withHashKey(key.getHashField, key.getHashValue)
     createRangeKeyCondition(key).foreach(rangeKeyCondition => querySpec.withRangeKeyCondition(rangeKeyCondition))
@@ -122,9 +130,11 @@ private[dynamodb] class DynamoDBMapStorePlugin @Inject() (dynamoDBClient: Amazon
     table.query(querySpec).asScala.map(_.asMap()).toList.asJava
   }
 
-  override def putItem(tableName: String,
-                       key: MapStoreKey,
-                       payload: java.util.Map[String, AnyRef]): java.util.Map[String, AnyRef] = {
+  override def putItem(
+    tableName: String,
+    key: MapStoreKey,
+    payload: java.util.Map[String, AnyRef]
+  ): java.util.Map[String, AnyRef] = {
     val table = dynamoDB.getTable(tableName)
     val primaryKey = createPrimaryKey(key)
 
@@ -139,9 +149,11 @@ private[dynamodb] class DynamoDBMapStorePlugin @Inject() (dynamoDBClient: Amazon
     Option(putItemOutcome.getItem).map(_.asMap()).getOrElse(item.asMap())
   }
 
-  override def updateItem(tableName: String,
-                          key: MapStoreKey,
-                          payload: java.util.Map[String, AnyRef]): java.util.Map[String, AnyRef] = {
+  override def updateItem(
+    tableName: String,
+    key: MapStoreKey,
+    payload: java.util.Map[String, AnyRef]
+  ): java.util.Map[String, AnyRef] = {
     val table = dynamoDB.getTable(tableName)
     val primaryKey = createPrimaryKey(key)
 

--- a/mapstore-dynamodb/src/main/scala/net/spals/appbuilder/mapstore/dynamodb/DynamoDBMapStoreUtil.scala
+++ b/mapstore-dynamodb/src/main/scala/net/spals/appbuilder/mapstore/dynamodb/DynamoDBMapStoreUtil.scala
@@ -1,0 +1,77 @@
+package net.spals.appbuilder.mapstore.dynamodb
+
+import com.amazonaws.services.dynamodbv2.document.spec.QuerySpec
+import com.amazonaws.services.dynamodbv2.document.{PrimaryKey, RangeKeyCondition}
+import com.amazonaws.services.dynamodbv2.model.ScalarAttributeType
+import com.google.common.annotations.VisibleForTesting
+import net.spals.appbuilder.mapstore.core.model.MapRangeOperator.{Extended, Standard}
+import net.spals.appbuilder.mapstore.core.model.{MapQueryOptions, MapStoreKey}
+import net.spals.appbuilder.mapstore.core.model.TwoValueMapRangeKey.TwoValueHolder
+
+import scala.compat.java8.OptionConverters._
+
+/**
+  * Shared utilities for [[DynamoDBMapStorePlugin]]
+  * and [[DynamoDBMapStoreIndexPlugin]].
+  *
+  * @author tkral
+  */
+private[dynamodb] object DynamoDBMapStoreUtil {
+
+  private[dynamodb] def createAttributeType(fieldType: Class[_]): ScalarAttributeType = {
+    fieldType match {
+      case booleanType if booleanType.equals(classOf[Boolean]) => ScalarAttributeType.B
+      case byteType if byteType.equals(classOf[Byte]) => ScalarAttributeType.N
+      case doubleType if doubleType.equals(classOf[Double]) => ScalarAttributeType.N
+      case floatType if floatType.equals(classOf[Float]) => ScalarAttributeType.N
+      case intType if intType.equals(classOf[Int]) => ScalarAttributeType.N
+      case javaBooleanType if javaBooleanType.equals(classOf[java.lang.Boolean]) => ScalarAttributeType.B
+      case javaNumberType if classOf[java.lang.Number].isAssignableFrom(javaNumberType) => ScalarAttributeType.N
+      case longType if longType.equals(classOf[Long]) => ScalarAttributeType.N
+      case shortType if shortType.equals(classOf[Short]) => ScalarAttributeType.N
+      case _ => ScalarAttributeType.S
+    }
+  }
+
+  @VisibleForTesting
+  private[dynamodb] def createPrimaryKey(key: MapStoreKey): PrimaryKey = {
+    key.getRangeField.asScala
+      .map(rangeField => new PrimaryKey(key.getHashField, key.getHashValue, rangeField, key.getRangeKey.getValue))
+      .getOrElse(new PrimaryKey(key.getHashField, key.getHashValue))
+  }
+
+  @VisibleForTesting
+  private[dynamodb] def createQuerySpec(
+    key: MapStoreKey,
+    options: MapQueryOptions
+  ): QuerySpec = {
+    val querySpec = new QuerySpec().withHashKey(key.getHashField, key.getHashValue)
+    createRangeKeyCondition(key).foreach(rangeKeyCondition => querySpec.withRangeKeyCondition(rangeKeyCondition))
+
+    querySpec.withScanIndexForward(options.getOrder == MapQueryOptions.Order.ASC)
+    options.getLimit.asScala.foreach(limit => querySpec.withMaxResultSize(limit))
+    querySpec
+  }
+
+  @VisibleForTesting
+  private[dynamodb] def createRangeKeyCondition(key: MapStoreKey): Option[RangeKeyCondition] = {
+    key.getRangeField.asScala.flatMap(rangeField => {
+      val rangeKeyCondition = new RangeKeyCondition(rangeField)
+      (key.getRangeKey.getOperator, key.getRangeKey.getValue) match {
+        case (Standard.ALL, _) => Option.empty[RangeKeyCondition]
+        case (Standard.NONE, _) => Option.empty[RangeKeyCondition]
+        case (Standard.BETWEEN, rValue) =>
+          Option(rangeKeyCondition.between(rValue.asInstanceOf[TwoValueHolder[_]].getValue1,
+            rValue.asInstanceOf[TwoValueHolder[_]].getValue2))
+        case (Standard.EQUAL_TO, rValue) => Option(rangeKeyCondition.eq(rValue))
+        case (Standard.GREATER_THAN, rValue) => Option(rangeKeyCondition.gt(rValue))
+        case (Standard.GREATER_THAN_OR_EQUAL_TO, rValue) => Option(rangeKeyCondition.ge(rValue))
+        case (Standard.LESS_THAN, rValue) => Option(rangeKeyCondition.lt(rValue))
+        case (Standard.LESS_THAN_OR_EQUAL_TO, rValue) => Option(rangeKeyCondition.le(rValue))
+        case (Extended.STARTS_WITH, rValue) => Option(rangeKeyCondition.beginsWith(rValue.asInstanceOf[String]))
+        case (operator, _) =>
+          throw new IllegalArgumentException(s"DynamoDB cannot support the operator $operator")
+      }
+    })
+  }
+}

--- a/mapstore-mongodb-test/src/test/scala/net/spals/appbuilder/mapstore/mongodb/MongoDBMapStoreIndexPluginIT.scala
+++ b/mapstore-mongodb-test/src/test/scala/net/spals/appbuilder/mapstore/mongodb/MongoDBMapStoreIndexPluginIT.scala
@@ -1,0 +1,261 @@
+package net.spals.appbuilder.mapstore.mongodb
+
+import java.util.Optional
+
+import com.google.common.collect.ImmutableMap
+import io.opentracing.mock.{MockSpan, MockTracer}
+import net.spals.appbuilder.mapstore.core.model.MapQueryOptions.defaultOptions
+import net.spals.appbuilder.mapstore.core.model.MapStoreIndexName.indexName
+import net.spals.appbuilder.mapstore.core.model.SingleValueMapRangeKey.{equalTo => range_equalTo}
+import net.spals.appbuilder.mapstore.core.model.{MapStoreIndexName, MapStoreKey, MapStoreTableKey}
+import net.spals.appbuilder.mapstore.mongodb.MongoDBSpanMatcher.mongoDBSpan
+import org.bson.Document
+import org.hamcrest.Matcher
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers._
+import org.slf4j.LoggerFactory
+import org.testng.annotations._
+
+import scala.collection.JavaConverters._
+
+/**
+  * Integration tests for [[MongoDBMapStoreIndexPlugin]].
+  *
+  * @author tkral
+  */
+class MongoDBMapStoreIndexPluginIT {
+  private val LOGGER = LoggerFactory.getLogger(classOf[MongoDBMapStoreIndexPluginIT])
+
+  private val mongoDBTracer = new MockTracer()
+  private lazy val mongoClient = {
+    val mongoClientProvider = new MongoClientProvider(mongoDBTracer)
+    mongoClientProvider.host = System.getenv("MONGODB_IP")
+    mongoClientProvider.port = System.getenv("MONGODB_PORT").toInt
+
+    LOGGER.info(s"Connecting to mongoDB instance at ${mongoClientProvider.host}:${mongoClientProvider.port}")
+    mongoClientProvider.get()
+  }
+
+  private val applicationName = "MongoDBMapStoreIndexPluginIT"
+  private lazy val mongoDatabase = {
+    val mongoDatabaseProvider = new MongoDatabaseProvider(applicationName, mongoClient)
+    mongoDatabaseProvider.get()
+  }
+  private lazy val mapStorePlugin = new MongoDBMapStorePlugin(mongoClient, mongoDatabase)
+  private lazy val mapStoreIndexPlugin = new MongoDBMapStoreIndexPlugin(mongoDatabase, mapStorePlugin)
+
+  private val hashIndexName = indexName("hashTable", "hashIndex")
+  private val hashTableKey = new MapStoreTableKey.Builder()
+    .setHash("tableHashField", classOf[String])
+    .build
+  private val hashIndexKey = new MapStoreTableKey.Builder()
+    .setHash("indexHashField", classOf[String])
+    .build
+
+  private val rangeIndexName = indexName("rangeTable", "rangeIndex")
+  private val rangeTableKey = new MapStoreTableKey.Builder()
+    .setHash("tableHashField", classOf[String])
+    .setRange("tableRangeField", classOf[String])
+    .build
+  private val rangeIndexKey = new MapStoreTableKey.Builder()
+    .setHash("indexHashField", classOf[String])
+    .setRange("indexRangeField", classOf[String])
+    .build
+
+  @BeforeClass def createTablesAndIndexes() {
+    mapStorePlugin.createTable(hashIndexName.getTableName, hashTableKey)
+    mapStoreIndexPlugin.createIndex(hashIndexName, hashIndexKey)
+
+    mapStorePlugin.createTable(rangeIndexName.getTableName, rangeTableKey)
+    mapStoreIndexPlugin.createIndex(rangeIndexName, rangeIndexKey)
+  }
+
+  @BeforeMethod def resetTracer() {
+    mongoDBTracer.reset()
+  }
+
+  @AfterClass(alwaysRun = true) def tearDownClass() {
+    mapStoreIndexPlugin.dropIndex(hashIndexName)
+    mapStoreIndexPlugin.dropIndex(rangeIndexName)
+
+    mapStorePlugin.dropTable(hashIndexName.getTableName)
+    mapStorePlugin.dropTable(rangeIndexName.getTableName)
+
+    mapStoreIndexPlugin.close()
+    mapStorePlugin.close()
+  }
+
+  @DataProvider def emptyGetProvider(): Array[Array[AnyRef]] = {
+    Array(
+      // Case: Hash-only key
+      Array(hashIndexName,
+        new MapStoreKey.Builder().setHash("indexHashField", "deadbeef").build),
+      // Case: Hash and range key
+      Array(rangeIndexName,
+        new MapStoreKey.Builder().setHash("indexHashField", "deadbeef")
+          .setRange("indexRangeField", range_equalTo[String]("deadbeef")).build)
+    )
+  }
+
+  @Test(
+    dataProvider = "emptyGetProvider",
+    groups = Array("MongoDBMapStoreIndexPluginIT.empty")
+  )
+  def testEmptyGetItem(
+    indexName: MapStoreIndexName,
+    storeKey: MapStoreKey
+  ) {
+    assertThat(mapStoreIndexPlugin.getItem(indexName, storeKey), is(Optional.empty[java.util.Map[String, AnyRef]]))
+    assertThat(mongoDBTracer.finishedSpans(), contains[MockSpan](mongoDBSpan("find")))
+  }
+
+  @Test(
+    dataProvider = "emptyGetProvider",
+    groups = Array("MongoDBMapStoreIndexPluginIT.empty")
+  )
+  def testEmptyGetItems(
+    indexName: MapStoreIndexName,
+    storeKey: MapStoreKey
+  ) {
+    assertThat(mapStoreIndexPlugin.getItems(indexName, storeKey, defaultOptions()), empty[java.util.Map[String, AnyRef]])
+    assertThat(mongoDBTracer.finishedSpans(), contains[MockSpan](mongoDBSpan("find")))
+  }
+
+  @Test(
+    groups = Array("MongoDBMapStoreIndexPluginIT.get"),
+    dependsOnGroups = Array("MongoDBMapStoreIndexPluginIT.empty")
+  )
+  def testGetItemHashOnly() {
+    val tableItemKey = new MapStoreKey.Builder().setHash("tableHashField", "table").build
+    mapStorePlugin.putItem(hashIndexName.getTableName, tableItemKey,
+      Map("indexHashField" -> "index").asJava.asInstanceOf[java.util.Map[String, AnyRef]])
+
+    val indexItemKey = new MapStoreKey.Builder().setHash("indexHashField", "index").build
+    val indexItem = mapStoreIndexPlugin.getItem(hashIndexName, indexItemKey)
+    assertThat(indexItem, not(Optional.empty[java.util.Map[String, AnyRef]]))
+
+    val itemMatcher: Matcher[Document] =
+      equalTo(new Document(ImmutableMap.of("tableHashField", "table", "indexHashField", "index")))
+    assertThat(indexItem.get.asInstanceOf[Document], itemMatcher)
+    assertThat(mongoDBTracer.finishedSpans(), contains[MockSpan](
+      mongoDBSpan("insert"),
+      mongoDBSpan("find")
+    ))
+  }
+
+  @Test(
+    groups = Array("MongoDBMapStoreIndexPluginIT.get"),
+    dependsOnGroups = Array("MongoDBMapStoreIndexPluginIT.empty")
+  )
+  def testGetItemHashRange() {
+    val tableItemKey = new MapStoreKey.Builder().setHash("tableHashField", "table")
+      .setRange("tableRangeField", range_equalTo[String]("1")).build
+    mapStorePlugin.putItem(rangeIndexName.getTableName, tableItemKey,
+      Map("indexHashField" -> "index", "indexRangeField" -> "11").asJava.asInstanceOf[java.util.Map[String, AnyRef]])
+
+    val indexItemKey = new MapStoreKey.Builder().setHash("indexHashField", "index")
+      .setRange("indexRangeField", range_equalTo[String]("11")).build
+    val indexItem = mapStoreIndexPlugin.getItem(rangeIndexName, indexItemKey)
+    assertThat(indexItem, not(Optional.empty[java.util.Map[String, AnyRef]]))
+
+    val itemMatcher: Matcher[Document] =
+      equalTo(new Document(ImmutableMap.of(
+        "tableHashField", "table", "tableRangeField", "1",
+        "indexHashField", "index", "indexRangeField", "11"
+      )))
+    assertThat(indexItem.get.asInstanceOf[Document], itemMatcher)
+    assertThat(mongoDBTracer.finishedSpans(), contains[MockSpan](
+      mongoDBSpan("insert"),
+      mongoDBSpan("find")
+    ))
+  }
+
+  @Test(
+    groups = Array("MongoDBMapStoreIndexPluginIT.update"),
+    dependsOnGroups = Array("MongoDBMapStoreIndexPluginIT.get")
+  )
+  def testUpdateItemHashOnly() {
+    val tableItemKey = new MapStoreKey.Builder().setHash("tableHashField", "table").build
+    mapStorePlugin.updateItem(hashIndexName.getTableName, tableItemKey,
+      Map("key" -> "value").asJava.asInstanceOf[java.util.Map[String, AnyRef]])
+
+    val indexItemKey = new MapStoreKey.Builder().setHash("indexHashField", "index").build
+    val indexItem = mapStoreIndexPlugin.getItem(hashIndexName, indexItemKey)
+    assertThat(indexItem, not(Optional.empty[java.util.Map[String, AnyRef]]))
+
+    val itemMatcher: Matcher[java.util.Map[String, AnyRef]] =
+      equalTo(new Document(ImmutableMap.of(
+        "tableHashField", "table", "indexHashField", "index",
+        "key", "value"
+      )))
+    assertThat(indexItem.get.asInstanceOf[Document], itemMatcher)
+    assertThat(mongoDBTracer.finishedSpans(), contains[MockSpan](
+      mongoDBSpan("findandmodify"),
+      mongoDBSpan("find")
+    ))
+  }
+
+  @Test(
+    groups = Array("MongoDBMapStoreIndexPluginIT.update"),
+    dependsOnGroups = Array("MongoDBMapStoreIndexPluginIT.get")
+  )
+  def testUpdateItemHashRange() {
+    val tableItemKey = new MapStoreKey.Builder().setHash("tableHashField", "table")
+      .setRange("tableRangeField", range_equalTo[String]("1")).build
+    mapStorePlugin.updateItem(rangeIndexName.getTableName, tableItemKey,
+      Map("key" -> "value").asJava.asInstanceOf[java.util.Map[String, AnyRef]])
+
+    val indexItemKey = new MapStoreKey.Builder().setHash("indexHashField", "index")
+      .setRange("indexRangeField", range_equalTo[String]("11")).build
+    val indexItem = mapStoreIndexPlugin.getItem(rangeIndexName, indexItemKey)
+    assertThat(indexItem, not(Optional.empty[java.util.Map[String, AnyRef]]))
+
+    val itemMatcher: Matcher[Document] =
+      equalTo(new Document(ImmutableMap.of(
+        "tableHashField", "table", "tableRangeField", "1",
+        "indexHashField", "index", "indexRangeField", "11",
+        "key", "value"
+      )))
+    assertThat(indexItem.get.asInstanceOf[Document], itemMatcher)
+    assertThat(mongoDBTracer.finishedSpans(), contains[MockSpan](
+      mongoDBSpan("findandmodify"),
+      mongoDBSpan("find")
+    ))
+  }
+
+  @Test(
+    groups = Array("MongoDBMapStoreIndexPluginIT.delete"),
+    dependsOnGroups = Array("MongoDBMapStoreIndexPluginIT.update")
+  )
+  def testDeleteItemHashOnly() {
+    val tableItemKey = new MapStoreKey.Builder().setHash("tableHashField", "table").build
+    mapStorePlugin.deleteItem(hashIndexName.getTableName, tableItemKey)
+
+    val indexItemKey = new MapStoreKey.Builder().setHash("indexHashField", "index").build
+    val indexItem = mapStoreIndexPlugin.getItem(hashIndexName, indexItemKey)
+    assertThat(indexItem, is(Optional.empty[java.util.Map[String, AnyRef]]))
+    assertThat(mongoDBTracer.finishedSpans(), contains[MockSpan](
+      mongoDBSpan("delete"),
+      mongoDBSpan("find")
+    ))
+  }
+
+  @Test(
+    groups = Array("MongoDBMapStoreIndexPluginIT.delete"),
+    dependsOnGroups = Array("MongoDBMapStoreIndexPluginIT.update")
+  )
+  def testDeleteItemHashRange() {
+    val tableItemKey = new MapStoreKey.Builder().setHash("tableHashField", "table")
+      .setRange("tableRangeField", range_equalTo[String]("1")).build
+    mapStorePlugin.deleteItem(rangeIndexName.getTableName, tableItemKey)
+
+    val indexItemKey = new MapStoreKey.Builder().setHash("indexHashField", "index")
+      .setRange("indexRangeField", range_equalTo[String]("11")).build
+    val indexItem = mapStoreIndexPlugin.getItem(rangeIndexName, indexItemKey)
+    assertThat(indexItem, is(Optional.empty[java.util.Map[String, AnyRef]]))
+    assertThat(mongoDBTracer.finishedSpans(), contains[MockSpan](
+      mongoDBSpan("delete"),
+      mongoDBSpan("find")
+    ))
+  }
+}

--- a/mapstore-mongodb-test/src/test/scala/net/spals/appbuilder/mapstore/mongodb/MongoDBSpanMatcher.scala
+++ b/mapstore-mongodb-test/src/test/scala/net/spals/appbuilder/mapstore/mongodb/MongoDBSpanMatcher.scala
@@ -1,0 +1,36 @@
+package net.spals.appbuilder.mapstore.mongodb
+
+import io.opentracing.mock.MockSpan
+import org.hamcrest.Matchers.{containsString, hasEntry, is}
+import org.hamcrest.{Description, Matcher, TypeSafeMatcher}
+
+/**
+  * A Hamcrest [[org.hamcrest.Matcher]] used
+  * to match tracing spans specific to MongoDB.
+  *
+  * @author tkral
+  */
+private[mongodb] object MongoDBSpanMatcher {
+
+  def mongoDBSpan(operation: String): MongoDBSpanMatcher =
+    MongoDBSpanMatcher(operation)
+}
+
+private[mongodb] case class MongoDBSpanMatcher(
+  operation: String
+) extends TypeSafeMatcher[MockSpan] {
+
+  override def matchesSafely(mockSpan: MockSpan): Boolean = {
+    hasEntry[String, AnyRef]("component", "java-mongo").matches(mockSpan.tags()) &&
+      hasEntry[String, AnyRef](is("db.statement"), containsString(operation).asInstanceOf[Matcher[AnyRef]])
+        .matches(mockSpan.tags()) &&
+      hasEntry[String, AnyRef]("db.type", "mongo").matches(mockSpan.tags()) &&
+      hasEntry[String, AnyRef]("span.kind", "client").matches(mockSpan.tags()) &&
+      operation.equals(mockSpan.operationName())
+  }
+
+  override def describeTo(description: Description): Unit = {
+    description.appendText("a MongoDB span tagged with operation ")
+    description.appendText(operation)
+  }
+}

--- a/mapstore-mongodb/src/main/scala/net/spals/appbuilder/mapstore/mongodb/MongoDBMapStoreIndexPlugin.scala
+++ b/mapstore-mongodb/src/main/scala/net/spals/appbuilder/mapstore/mongodb/MongoDBMapStoreIndexPlugin.scala
@@ -1,0 +1,75 @@
+package net.spals.appbuilder.mapstore.mongodb
+
+import java.util
+import java.util.Optional
+import javax.annotation.PreDestroy
+
+import com.google.inject.Inject
+import com.mongodb.MongoClient
+import com.mongodb.client.MongoDatabase
+import com.mongodb.client.model._
+import net.spals.appbuilder.annotations.service.AutoBindInMap
+import net.spals.appbuilder.mapstore.core.model.{MapQueryOptions, MapStoreIndexName, MapStoreKey, MapStoreTableKey}
+import net.spals.appbuilder.mapstore.core.{MapStore, MapStoreIndexPlugin}
+
+/**
+  * Implementation of [[MapStoreIndexPlugin]] which
+  * uses MongoDB.
+  *
+  * NOTE: This implementation follows the semantics
+  * of a [[MapStore]], not a document store. As such,
+  * it intentionally removes or ignores some default
+  * functionality provided by MongoDB. For example,
+  * this implementation ignores MongoDB's text and
+  * geo search capabilities.
+  *
+  * If an application developer wishes to use more
+  * advanced features of MongoDB, they should inject
+  * the [[MongoClient]] and [[MongoDatabase]] directly
+  * into their own custom services.
+  *
+  * @author tkral
+  */
+@AutoBindInMap(baseClass = classOf[MapStoreIndexPlugin], key = "mongoDB")
+private[mongodb] class MongoDBMapStoreIndexPlugin @Inject()(
+  mongoDatabase: MongoDatabase,
+  mapStore: MapStore
+) extends MapStoreIndexPlugin {
+
+  @PreDestroy
+  override def close(): Unit = ()
+
+  override def createIndex(
+    indexName: MapStoreIndexName,
+    indexKey: MapStoreTableKey
+  ): Boolean = {
+    // From MongoDB: Currently only single field hashed index supported.
+    val hashIndex = Indexes.hashed(indexKey.getHashField)
+
+    val collection = mongoDatabase.getCollection(indexName.getTableName)
+    val indexOptions = new IndexOptions().name(indexName.getIndexName)
+    indexName.getIndexName.equals(collection.createIndex(hashIndex, indexOptions))
+  }
+
+
+  override def dropIndex(indexName: MapStoreIndexName): Boolean = {
+    val collection = mongoDatabase.getCollection(indexName.getTableName)
+    collection.dropIndex(indexName.getIndexName)
+    true
+  }
+
+  override def getItem(
+    indexName: MapStoreIndexName,
+    key: MapStoreKey
+  ): Optional[util.Map[String, AnyRef]] = {
+    mapStore.getItem(indexName.getTableName, key)
+  }
+
+  override def getItems(
+    indexName: MapStoreIndexName,
+    key: MapStoreKey,
+    options: MapQueryOptions
+  ): util.List[util.Map[String, AnyRef]] = {
+    mapStore.getItems(indexName.getTableName, key, options)
+  }
+}

--- a/mapstore-mongodb/src/main/scala/net/spals/appbuilder/mapstore/mongodb/MongoDBMapStorePlugin.scala
+++ b/mapstore-mongodb/src/main/scala/net/spals/appbuilder/mapstore/mongodb/MongoDBMapStorePlugin.scala
@@ -73,9 +73,7 @@ private[mongodb] class MongoDBMapStorePlugin @Inject() (
 
         val collection = mongoDatabase.getCollection(tableName)
         val indexOptions = new IndexOptions().name("primary")
-        val indexName = collection.createIndex(hashIndex, indexOptions)
-
-        "primary".equals(indexName)
+        "primary".equals(collection.createIndex(hashIndex, indexOptions))
       }
     }
   }

--- a/mapstore-mongodb/src/main/scala/net/spals/appbuilder/mapstore/mongodb/MongoDBMapStorePlugin.scala
+++ b/mapstore-mongodb/src/main/scala/net/spals/appbuilder/mapstore/mongodb/MongoDBMapStorePlugin.scala
@@ -46,7 +46,7 @@ import scala.compat.java8.OptionConverters._
 private[mongodb] class MongoDBMapStorePlugin @Inject() (
   mongoClient: MongoClient,
   mongoDatabase: MongoDatabase
-) extends MapStorePlugin with Closeable {
+) extends MapStorePlugin {
 
   private val ID_FIELD_NAME = "_id"
 


### PR DESCRIPTION
@thespags @john-brock 

Adding a new service to support indexes within the `MapStore` service. The new service is called `MapStoreIndex`.

Indexes are read-only. They are populated by writing to the parent table through the `MapStore` service. The read methods are the same as what you'll find in `MapStore`.

`MapStoreIndex` is a completely separate service that you will need to inject whenever you need to read from an index. I've included implementations for the following plugins: `MapDB`, `DynamoDB`, and `MongoDB`. Notice that `Cassandra` is missing from this list. This is because indexes are considered poor practice when using Cassandra. By writing `MapStoreIndex` as a separate service, I was able to leave out a Cassandra implementation.