### PR TITLE
Allow MongoDB MapStore to be configured with single URL

### DIFF
--- a/mapstore-mongodb-test/src/test/scala/net/spals/appbuilder/mapstore/mongodb/MongoDatabaseProviderTest.scala
+++ b/mapstore-mongodb-test/src/test/scala/net/spals/appbuilder/mapstore/mongodb/MongoDatabaseProviderTest.scala
@@ -1,0 +1,41 @@
+package net.spals.appbuilder.mapstore.mongodb
+
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.is
+import org.testng.annotations.{DataProvider, Test}
+
+/**
+  * Unit tests for [[MongoDatabaseProvider]].
+  *
+  * @author tkral
+  */
+class MongoDatabaseProviderTest {
+
+  @DataProvider def databaseNameProvider(): Array[Array[AnyRef]] = {
+    Array(
+      // Case: Fallback to application name if no configuration is present
+      Array(null, null, "applicationName"),
+      // Case: Use explicitly configured database name
+      Array("configuredDatabaseName", null, "configuredDatabaseName"),
+      // Case: Use database name from URL
+      Array(null, "mongodb://host:123/urlDB", "urlDB"),
+      // Case: Use database name from URL with collection specified
+      Array(null, "mongodb://host:123/urlDB.collection", "urlDB"),
+      // Case: Take URL database name over configured database name
+      Array("configuredDatabaseName", "mongodb://host:123/urlDB", "urlDB")
+    )
+  }
+
+  @Test(dataProvider = "databaseNameProvider")
+  def testDatabaseName(
+    configuredDatabaseName: String,
+    url: String,
+    expectedDatabaseName: String
+  ) {
+    val mongoDatabaseProvider = new MongoDatabaseProvider("applicationName", mongoClient = null)
+    mongoDatabaseProvider.configuredDatabaseName = configuredDatabaseName
+    mongoDatabaseProvider.url = url
+
+    assertThat(mongoDatabaseProvider.databaseName, is(expectedDatabaseName))
+  }
+}

--- a/mapstore-mongodb/src/main/scala/net/spals/appbuilder/mapstore/mongodb/MongoDBMapStorePlugin.scala
+++ b/mapstore-mongodb/src/main/scala/net/spals/appbuilder/mapstore/mongodb/MongoDBMapStorePlugin.scala
@@ -10,16 +10,15 @@ import com.mongodb.MongoClient
 import com.mongodb.client.MongoDatabase
 import com.mongodb.client.model._
 import net.spals.appbuilder.annotations.service.AutoBindInMap
-import net.spals.appbuilder.mapstore.core.{MapStore, MapStorePlugin}
 import net.spals.appbuilder.mapstore.core.MapStorePlugin.stripKey
 import net.spals.appbuilder.mapstore.core.model.MapQueryOptions.Order
 import net.spals.appbuilder.mapstore.core.model.MapRangeOperator.{Extended, Standard}
 import net.spals.appbuilder.mapstore.core.model.MultiValueMapRangeKey.ListValueHolder
 import net.spals.appbuilder.mapstore.core.model.TwoValueMapRangeKey.TwoValueHolder
 import net.spals.appbuilder.mapstore.core.model.{MapQueryOptions, MapStoreKey, MapStoreTableKey}
+import net.spals.appbuilder.mapstore.core.{MapStore, MapStorePlugin}
 import org.bson.Document
 import org.bson.conversions.Bson
-import org.slf4j.LoggerFactory
 
 import scala.collection.JavaConverters._
 import scala.compat.java8.OptionConverters._

--- a/mapstore-mongodb/src/main/scala/net/spals/appbuilder/mapstore/mongodb/MongoDatabaseProvider.scala
+++ b/mapstore-mongodb/src/main/scala/net/spals/appbuilder/mapstore/mongodb/MongoDatabaseProvider.scala
@@ -1,13 +1,13 @@
 package net.spals.appbuilder.mapstore.mongodb
 
-import javax.validation.constraints.NotNull
-
+import com.google.common.annotations.VisibleForTesting
 import com.google.inject.{Inject, Provider}
-import com.mongodb.MongoClient
 import com.mongodb.client.MongoDatabase
+import com.mongodb.{MongoClient, MongoClientURI}
 import com.netflix.governator.annotations.Configuration
 import net.spals.appbuilder.annotations.config.ApplicationName
 import net.spals.appbuilder.annotations.service.AutoBindProvider
+import org.slf4j.LoggerFactory
 
 /**
   * @author tkral
@@ -17,13 +17,27 @@ private[mongodb] class MongoDatabaseProvider @Inject() (
   @ApplicationName applicationName: String,
   mongoClient: MongoClient
 ) extends Provider[MongoDatabase] {
+  private val LOGGER = LoggerFactory.getLogger(classOf[MongoDatabaseProvider])
 
-  @NotNull
   @Configuration("mapStore.mongoDB.database")
   @volatile
+  @VisibleForTesting
   private[mongodb] var configuredDatabaseName: String = null
 
-  private lazy val databaseName = Option(configuredDatabaseName).getOrElse(applicationName)
+  @Configuration("mapStore.mongoDB.url")
+  @volatile
+  @VisibleForTesting
+  private[mongodb] var url: String = null
 
-  override def get(): MongoDatabase = mongoClient.getDatabase(databaseName)
+  @VisibleForTesting
+  private[mongodb] lazy val databaseName = {
+    val mongoClientURI = Option(url).map(new MongoClientURI(_))
+    mongoClientURI.map(_.getDatabase)
+      .getOrElse(Option(configuredDatabaseName).getOrElse(applicationName))
+  }
+
+  override def get(): MongoDatabase = {
+    LOGGER.info(s"MongoDB database is: ${databaseName}")
+    mongoClient.getDatabase(databaseName)
+  }
 }


### PR DESCRIPTION
@thespags @john-brock 

Fulfilling request from @thespags to allow MongoDB to be configured with a single URL. This means that we'll now be able to take the database name from the URL.