### PR TITLE
Package relocation rules for bundles

### DIFF
--- a/annotations/pom.xml
+++ b/annotations/pom.xml
@@ -18,6 +18,17 @@
             <groupId>com.google.inject</groupId>
             <artifactId>guice</artifactId>
         </dependency>
+        <!-- Include common annotations in the bundle -->
+        <dependency>
+            <groupId>com.google.inject.extensions</groupId>
+            <artifactId>guice-assistedinject</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.netflix.governator</groupId>
+            <artifactId>governator-api</artifactId>
+            <scope>runtime</scope>
+        </dependency>
     </dependencies>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -743,6 +743,45 @@
                                 <configuration>
                                     <createSourcesJar>true</createSourcesJar>
                                     <minimizeJar>true</minimizeJar>
+                                    <!-- Relocation common packages that applications may want to upgrade -->
+                                    <relocations>
+                                        <relocation>
+                                            <pattern>com.amazonaws</pattern>
+                                            <shadedPattern>net.spals.shaded.com.amazonaws</shadedPattern>
+                                        </relocation>
+                                        <relocation>
+                                            <pattern>com.fasterxml.jackson</pattern>
+                                            <shadedPattern>net.spals.shaded.com.fasterxml.jackson</shadedPattern>
+                                        </relocation>
+                                        <relation>
+                                            <pattern>com.google.auto.value</pattern>
+                                            <shadedPattern>net.spals.shaded.com.google.auto.value</shadedPattern>
+                                        </relation>
+                                        <relocation>
+                                            <pattern>com.google.common</pattern>
+                                            <shadedPattern>net.spals.shaded.com.google.common</shadedPattern>
+                                        </relocation>
+                                        <relocation>
+                                            <pattern>com.google.protobuf</pattern>
+                                            <shadedPattern>net.spals.shaded.com.google.protobuf</shadedPattern>
+                                        </relocation>
+                                        <relocation>
+                                            <pattern>org.apache.http</pattern>
+                                            <shadedPattern>net.spals.shaded.org.apache.http</shadedPattern>
+                                        </relocation>
+                                        <relocation>
+                                            <pattern>org.inferred.freebuilder</pattern>
+                                            <shadedPattern>net.spals.shaded.org.inferred.freebuilder</shadedPattern>
+                                        </relocation>
+                                        <relocation>
+                                            <pattern>org.joda.time</pattern>
+                                            <shadedPattern>net.spals.shaded.org.joda.time</shadedPattern>
+                                        </relocation>
+                                        <relocation>
+                                            <pattern>org.yaml.snakeyaml</pattern>
+                                            <shadedPattern>net.spals.shaded.org.yaml.snakeyaml</shadedPattern>
+                                        </relocation>
+                                    </relocations>
                                     <shadedArtifactAttached>true</shadedArtifactAttached>
                                     <shadedClassifierName>bundle</shadedClassifierName>
                                     <shadeTestJar>false</shadeTestJar>


### PR DESCRIPTION
Adding relocation for common packages in bundle JARs. This will allow these libraries to be independently upgraded in applications using AppBuilder.

@thespags 