### PR TITLE
Add ModelSerializerRegistry

### DIFF
--- a/model-core/src/main/java/net/spals/appbuilder/model/core/DefaultModelSerializerRegistry.java
+++ b/model-core/src/main/java/net/spals/appbuilder/model/core/DefaultModelSerializerRegistry.java
@@ -1,0 +1,34 @@
+package net.spals.appbuilder.model.core;
+
+import com.google.inject.Inject;
+import net.spals.appbuilder.annotations.service.AutoBindSingleton;
+
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Default implementation of {@link ModelSerializerRegistry}.
+ *
+ * @author tkral
+ */
+@AutoBindSingleton
+class DefaultModelSerializerRegistry implements ModelSerializerRegistry {
+
+    private final Map<String, ModelSerializer> serializerMap;
+
+    @Inject
+    DefaultModelSerializerRegistry(final Map<String, ModelSerializer> serializerMap) {
+        this.serializerMap = serializerMap;
+    }
+
+
+    @Override
+    public Set<String> getAvailableModelSerializers() {
+        return serializerMap.keySet();
+    }
+
+    @Override
+    public ModelSerializer getModelSerializer(final String key) {
+        return serializerMap.get(key);
+    }
+}

--- a/model-core/src/main/java/net/spals/appbuilder/model/core/ModelSerializerRegistry.java
+++ b/model-core/src/main/java/net/spals/appbuilder/model/core/ModelSerializerRegistry.java
@@ -1,0 +1,24 @@
+package net.spals.appbuilder.model.core;
+
+import java.util.Set;
+
+/**
+ * A service definition of a registry of
+ * all available {@link ModelSerializer}s.
+ *
+ * @author tkral
+ */
+public interface ModelSerializerRegistry {
+
+    /**
+     * Return the keys of all {@link ModelSerializer}s
+     * registered in this registry.
+     */
+    Set<String> getAvailableModelSerializers();
+
+    /**
+     * Find the {@link ModelSerializer} instance
+     * registered with this registry using the given key.
+     */
+    ModelSerializer getModelSerializer(final String key);
+}


### PR DESCRIPTION
@thespags 

Adding a simple registry service which makes it slightly easier to access `ModelSerializer` services added in the AppBuilder framework.